### PR TITLE
Add Mnemosyne memory dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Current scope:
   * Honcho memory:
     + read-only Honcho workspace, host, peer, and provider configuration state
     + user/AI peer cards, representations, conclusions, and context search
+  * Mnemosyne memory:
+    + read-only local SQLite store inspection for episodes, facts, instructions, gists, and graph rows
+    + explicit recall and injected-context preview through the Hermes Mnemosyne provider
   * Hindsight memory:
     + read-only/query-only Hindsight provider configuration state
     + explicit recall and reflect actions; no automatic retain/write flow
@@ -106,6 +109,7 @@ Top summary:
 - holographic total fact count only when `memory.provider` is currently `holographic`
 - Mem0 memory count only when `memory.provider` is currently `mem0`
 - Honcho peer-card fact count only when `memory.provider` is currently `honcho`
+- Mnemosyne episode count only when `memory.provider` is currently `mnemosyne`
 - Hindsight bank/status only when `memory.provider` is currently `hindsight`
 
 Built-in memory section:
@@ -143,6 +147,16 @@ Honcho memory section, displayed when `memory.provider` is currently `honcho`:
 - user and AI representations
 - conclusions returned for user and AI peers
 - context search after clicking `Apply / refresh` button
+
+Mnemosyne memory section, displayed when `memory.provider` is currently `mnemosyne`:
+
+- whether Mnemosyne is the active provider
+- local data directory and SQLite DB path
+- table counts for episodic memory, Memoria facts/instructions/preferences/timelines, gists, triples, and vector row indexes
+- memory and fact cards from the local SQLite store, with search and limit filters
+- explicit `Recall` query button for ranked memory retrieval through Hermes' Mnemosyne provider
+- explicit `Preview inject` button for the exact prefetch/auto-inject context returned by the provider
+- no remember/sleep/update/forget/import/export endpoint
 
 Hindsight memory section, displayed when `memory.provider` is currently `hindsight`:
 
@@ -231,6 +245,25 @@ The plugin performs read-only calls such as:
 
 It does not call Honcho dialectic reasoning (`peer.chat()` / `honcho_reasoning`) automatically from page load or `/snapshot`.
 
+## Mnemosyne configuration
+
+Mnemosyne support follows Hermes' Mnemosyne memory provider convention. The plugin reads non-secret state from:
+
+- `memory.provider: mnemosyne` in `$HERMES_HOME/config.yaml`
+- `$HERMES_HOME/mnemosyne/data/mnemosyne.db` by default
+- optional `memory.mnemosyne.data_dir` / `memory.mnemosyne.db_path`
+- optional environment variables such as `MNEMOSYNE_DATA_DIR`, `MNEMOSYNE_DB_PATH`, `MNEMOSYNE_PREFETCH_CONTENT_CHARS`, and `MNEMOSYNE_AUTO_SLEEP_ENABLED`
+
+The SQLite connection is opened in read-only mode using `mode=ro`. The dashboard reads ordinary text tables such as `episodic_memory`, `memoria_facts`, `memoria_instructions`, `memoria_preferences`, `memoria_timelines`, `gists`, and `triples`. It deliberately does not query sqlite-vec virtual tables directly; it only counts their rowid side tables when present so the UI works without loading sqlite-vec into the dashboard process.
+
+The plugin performs query-only provider calls:
+
+- `MnemosyneMemoryProvider.initialize(...)`
+- `provider.handle_tool_call("mnemosyne_recall", ...)` for explicit recall
+- `provider.prefetch(...)` for injected-context preview
+
+It does not expose `mnemosyne_remember`, `mnemosyne_sleep`, `mnemosyne_update`, `mnemosyne_forget`, `mnemosyne_import`, or any other write/maintenance tool.
+
 ## Hindsight configuration
 
 Hindsight support follows Hermes' bundled `hindsight` memory provider convention. The plugin reads non-secret configuration from:
@@ -266,7 +299,7 @@ Available API endpoints:
 
 ### GET `/status`
 
-Returns plugin status, active Hermes home, configured memory provider, built-in memory paths, holographic DB path, Mem0 configuration status, Honcho configuration status, and Hindsight configuration status.
+Returns plugin status, active Hermes home, configured memory provider, built-in memory paths, holographic DB path, Mem0 configuration status, Honcho configuration status, Mnemosyne configuration status, and Hindsight configuration status.
 
 Example:
 
@@ -332,6 +365,49 @@ Example:
 curl 'http://127.0.0.1:9119/api/plugins/hermes-memory-ui/honcho?limit=25&search=dashboard' | jq
 ```
 
+### GET `/mnemosyne`
+
+Returns Mnemosyne provider status plus read-only local store contents.
+
+### GET `/mnemosyne/contents`
+
+Lists Mnemosyne local SQLite memory and fact rows. This is read-only.
+
+Query parameters:
+
+- `search`: optional text filter applied to visible memory/fact text and metadata columns
+- `limit`: optional, defaults to 25, capped at 100
+
+```bash
+curl 'http://127.0.0.1:9119/api/plugins/hermes-memory-ui/mnemosyne/contents?search=dashboard&limit=25' | jq
+```
+
+### GET `/mnemosyne/recall`
+
+Runs explicit Mnemosyne recall through the Hermes provider.
+
+Query parameters:
+
+- `query`: required query string
+- `limit`: 1-100, default 25
+- `temporal_weight`: 0.0-1.0, default 0.2
+
+```bash
+curl 'http://127.0.0.1:9119/api/plugins/hermes-memory-ui/mnemosyne/recall?query=dashboard&limit=25&temporal_weight=0.2' | jq
+```
+
+### GET `/mnemosyne/prefetch`
+
+Returns the injected-context preview generated by Mnemosyne prefetch.
+
+Query parameters:
+
+- `query`: required query string
+
+```bash
+curl 'http://127.0.0.1:9119/api/plugins/hermes-memory-ui/mnemosyne/prefetch?query=dashboard' | jq
+```
+
 ### GET `/hindsight`
 
 Returns Hindsight provider status/config only. It does not run recall or reflect.
@@ -380,7 +456,7 @@ curl 'http://127.0.0.1:9119/api/plugins/hermes-memory-ui/hindsight/reflect?query
 
 ### GET `/snapshot`
 
-Combined payload used by the UI. Accepts the same query parameters as `/holographic`; `limit` and `search` are also applied to Mem0 and Honcho, with Honcho internally capped at 100. Hindsight in `/snapshot` is status/config only and does not query recall/reflect.
+Combined payload used by the UI. Accepts the same query parameters as `/holographic`; `limit` and `search` are also applied to Mem0, Honcho, and Mnemosyne, with Honcho and Mnemosyne internally capped at 100. Hindsight in `/snapshot` is status/config only and does not query recall/reflect.
 
 ```bash
 curl http://127.0.0.1:9119/api/plugins/hermes-memory-ui/snapshot | jq
@@ -402,6 +478,7 @@ Memory writes are semantically loaded:
 
 - Built-in memory has limits, delimiter parsing, locking, duplicate handling, and prompt-injection scanning.
 - Holographic facts maintain FTS indexes, entity links, HRR vectors, trust scores, and memory banks.
+- Mnemosyne maintains embeddings, Memoria-derived structured tables, graph rows, sleep/consolidation flows, and provider-level recall semantics.
 - Built-in `memory(add)` may mirror into holographic memory, but `replace`, `remove`, and direct file edits do not reliably mirror.
 
 A dashboard that writes directly to files or SQLite can silently corrupt memory semantics.

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -595,6 +595,161 @@
     );
   }
 
+  function MnemosyneResultRow(props) {
+    const result = props.result;
+    const metadata = result.metadata && Object.keys(result.metadata).length ? JSON.stringify(result.metadata) : "";
+    const typeLabel = result.display_type || result.type;
+    return e("div", { className: "memory-ui-fact" },
+      e("div", { className: "memory-ui-fact-top" },
+        e("div", { className: "memory-ui-fact-id" }, "#" + result.id),
+        result.score !== null && result.score !== undefined ? e(Badge, { variant: "outline" }, "score " + Number(result.score).toFixed(3)) : null,
+        typeLabel ? e(Badge, { variant: "outline" }, String(typeLabel).toUpperCase()) : null,
+        result.source ? e(Badge, { variant: "outline" }, String(result.source)) : null
+      ),
+      e("div", { className: "memory-ui-fact-content" }, result.text || ""),
+      metadata ? e("div", { className: "memory-ui-tags" }, "metadata: ", metadata) : null,
+      result.timestamp || result.created_at ? e("div", { className: "memory-ui-muted" }, "Time: ", fmtTime(result.timestamp || result.created_at)) : null
+    );
+  }
+
+  function MnemosyneSection(props) {
+    const data = props.mnemosyne;
+    const [query, setQuery] = useState("");
+    const [limit, setLimit] = useState("25");
+    const [temporalWeight, setTemporalWeight] = useState("0.2");
+    const [operationData, setOperationData] = useState(null);
+    const [contentsData, setContentsData] = useState(null);
+    const [operationLoading, setOperationLoading] = useState(false);
+    const [contentsLoading, setContentsLoading] = useState(false);
+    const [operationError, setOperationError] = useState(null);
+    const [contentsError, setContentsError] = useState(null);
+    if (!data) return null;
+
+    function runOperation(kind) {
+      if (!query.trim()) {
+        setOperationError("Enter a query first.");
+        return;
+      }
+      const p = new URLSearchParams();
+      p.set("query", query);
+      if (kind === "recall") {
+        p.set("limit", limit || "25");
+        p.set("temporal_weight", temporalWeight || "0.2");
+      }
+      setOperationLoading(true);
+      setOperationError(null);
+      SDK.fetchJSON("/api/plugins/hermes-memory-ui/mnemosyne/" + kind + "?" + p.toString())
+        .then(function (payload) { setOperationData(payload); })
+        .catch(function (err) { setOperationError(err && err.message ? err.message : String(err)); })
+        .finally(function () { setOperationLoading(false); });
+    }
+
+    function refreshContents() {
+      const p = new URLSearchParams();
+      p.set("limit", limit || "25");
+      if (query.trim()) p.set("search", query);
+      setContentsLoading(true);
+      setContentsError(null);
+      SDK.fetchJSON("/api/plugins/hermes-memory-ui/mnemosyne/contents?" + p.toString())
+        .then(function (payload) { setContentsData(payload); })
+        .catch(function (err) { setContentsError(err && err.message ? err.message : String(err)); })
+        .finally(function () { setContentsLoading(false); });
+    }
+
+    const visibleContents = contentsData || data;
+    const results = operationData && operationData.results ? operationData.results : [];
+    const memoryItems = (visibleContents.memories || []).map(function (item) { return Object.assign({}, item, { display_type: "memory" }); });
+    const factItems = (visibleContents.facts || []).map(function (item) { return Object.assign({}, item, { display_type: "fact" }); });
+    const contentItems = memoryItems.concat(factItems);
+    return e("div", { className: "memory-ui-section" },
+      e("div", { className: "memory-ui-section-header" },
+        e("div", null,
+          e("h2", null, "Mnemosyne memory"),
+          e("p", null, "Read-only view of the local Mnemosyne SQLite store, plus explicit recall and injected-context preview.")
+        ),
+        e("div", { className: "memory-ui-badges" },
+          e(Badge, { variant: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
+          e(Badge, { variant: data.db_exists ? "outline" : "secondary" }, data.db_exists ? "db found" : "db missing"),
+          e(Badge, { variant: "outline" }, data.auto_sleep_enabled ? "sleep on" : "sleep off")
+        )
+      ),
+      e("div", { className: "memory-ui-grid-4" },
+        e(StatCard, { label: "Episodes", value: visibleContents.total_memories || 0, hint: "episodic + working rows" }),
+        e(StatCard, { label: "Facts", value: visibleContents.total_facts || 0, hint: "memoria facts and graph rows" }),
+        e(StatCard, { label: "Vectors", value: visibleContents.vector_rows || 0, hint: "sqlite-vec row index" }),
+        e(StatCard, { label: "Prefetch chars", value: data.prefetch_content_chars || "default", hint: "auto-inject budget" })
+      ),
+      e(Card, null,
+        e(CardContent, { className: "memory-ui-controls memory-ui-provider-controls" },
+          e("div", { className: "memory-ui-control" },
+            e("label", null, "Query / content filter"),
+            e(Input, {
+              value: query,
+              placeholder: "ask or filter Mnemosyne memory...",
+              onChange: function (ev) { setQuery(ev.target.value); }
+            })
+          ),
+          e("div", { className: "memory-ui-control" },
+            e("label", null, "Limit"),
+            e("select", {
+              className: "memory-ui-select",
+              value: limit,
+              onChange: function (ev) { setLimit(ev.target.value); }
+            },
+              e("option", { value: "10" }, "10"),
+              e("option", { value: "25" }, "25"),
+              e("option", { value: "50" }, "50"),
+              e("option", { value: "100" }, "100")
+            )
+          ),
+          e("div", { className: "memory-ui-control" },
+            e("label", null, "Temporal"),
+            e("select", {
+              className: "memory-ui-select",
+              value: temporalWeight,
+              onChange: function (ev) { setTemporalWeight(ev.target.value); }
+            },
+              e("option", { value: "0" }, "0.0"),
+              e("option", { value: "0.2" }, "0.2"),
+              e("option", { value: "0.5" }, "0.5"),
+              e("option", { value: "0.8" }, "0.8"),
+              e("option", { value: "1" }, "1.0")
+            )
+          ),
+          e("div", { className: "memory-ui-provider-actions" },
+            e(Button, { onClick: function () { runOperation("recall"); }, className: "memory-ui-refresh", disabled: operationLoading }, operationLoading ? "Running..." : "Recall"),
+            e(Button, { onClick: function () { runOperation("prefetch"); }, className: "memory-ui-refresh", disabled: operationLoading }, operationLoading ? "Running..." : "Preview inject")
+          )
+        )
+      ),
+      e(ErrorBox, { error: data.error || operationError || contentsError || (operationData && operationData.error) || (contentsData && contentsData.error) }),
+      e("div", { className: "memory-ui-path" }, visibleContents.db_path || data.db_path),
+      operationData && operationData.operation === "prefetch" ? e(Card, null,
+        e(CardContent, null,
+          e("div", { className: "memory-ui-muted" }, "Injected context preview · ", operationData.context_char_count || 0, " chars"),
+          operationData.context ? e("div", { className: "memory-ui-fact-content memory-ui-path" }, operationData.context) : e(EmptyState, null, "No context returned.")
+        )
+      ) : null,
+      operationData && operationData.operation === "recall" ? e("div", { className: "memory-ui-fact-list" },
+        operationData.result_source ? e("div", { className: "memory-ui-muted" }, "Result source: ", operationData.result_source) : null,
+        results.length
+          ? results.map(function (result, index) { return e(MnemosyneResultRow, { key: "mnemosyne-result-" + index, result: result }); })
+          : e(EmptyState, null, operationData.error ? "Mnemosyne recall is unavailable." : "No memories returned for this query.")
+      ) : null,
+      e("div", { className: "memory-ui-fact-list" },
+        e("div", { className: "memory-ui-contents-toolbar" },
+          e("div", { className: "memory-ui-muted" }, "Contents · memories: ", visibleContents.memory_count || 0, " / ", visibleContents.total_memories || 0, " · facts: ", visibleContents.fact_count || 0, " / ", visibleContents.total_facts || 0),
+          e(Button, { onClick: refreshContents, className: "memory-ui-refresh", disabled: contentsLoading }, contentsLoading ? "Refreshing..." : "Refresh contents")
+        ),
+        contentsLoading && !contentsData ? e(EmptyState, null, "Loading Mnemosyne contents...") : null,
+        !contentsLoading && contentItems.length
+          ? contentItems.map(function (result, index) { return e(MnemosyneResultRow, { key: "mnemosyne-content-" + index, result: result }); })
+          : null,
+        !contentsLoading && !contentItems.length ? e(EmptyState, null, data.db_exists ? "No Mnemosyne contents returned." : "Mnemosyne database does not exist yet.") : null
+      )
+    );
+  }
+
   function MemoryPage() {
     const [snapshot, setSnapshot] = useState(null);
     const [loading, setLoading] = useState(false);
@@ -625,12 +780,14 @@
     const holographic = snapshot && snapshot.holographic;
     const mem0 = snapshot && snapshot.mem0;
     const honcho = snapshot && snapshot.honcho;
+    const mnemosyne = snapshot && snapshot.mnemosyne;
     const hindsight = snapshot && snapshot.hindsight;
     const showHolographic = !!(holographic && holographic.provider_configured);
     const showMem0 = !!(mem0 && mem0.provider_configured);
     const showHoncho = !!(honcho && honcho.provider_configured);
+    const showMnemosyne = !!(mnemosyne && mnemosyne.provider_configured);
     const showHindsight = !!(hindsight && hindsight.provider_configured);
-    const heroGridClass = showHolographic || showMem0 || showHoncho || showHindsight ? "memory-ui-grid-4" : "memory-ui-grid-2";
+    const heroGridClass = showHolographic || showMem0 || showHoncho || showMnemosyne || showHindsight ? "memory-ui-grid-4" : "memory-ui-grid-2";
 
     return e("div", { className: "memory-ui-page" },
       e(Card, { className: "memory-ui-hero" },
@@ -652,6 +809,7 @@
             showHolographic ? e(StatCard, { label: "Facts", value: holographic ? holographic.total_facts : 0, hint: "holographic facts" }) : null,
             showMem0 ? e(StatCard, { label: "Mem0", value: mem0 ? mem0.total_memories : 0, hint: "Mem0 memories" }) : null,
             showHoncho ? e(StatCard, { label: "Honcho", value: honcho ? ((honcho.user.card || []).length + (honcho.ai.card || []).length) : 0, hint: "peer card facts" }) : null,
+            showMnemosyne ? e(StatCard, { label: "Mnemosyne", value: mnemosyne ? (mnemosyne.total_memories || 0) : 0, hint: "local episodes" }) : null,
             showHindsight ? e(StatCard, { label: "Hindsight", value: hindsight ? (hindsight.bank_id || "active") : "—", hint: "query-only memory" }) : null,
             e(StatCard, { label: "Hermes home", value: builtin ? "active" : "—", hint: builtin ? builtin.hermes_home : "loading" }),
             e(StatCard, { label: "Generated", value: snapshot.generated_at ? fmtTime(snapshot.generated_at) : "—", hint: "snapshot time" })
@@ -671,6 +829,10 @@
         showHoncho ? e(React.Fragment, null,
           e(Separator, null),
           e(HonchoSection, { honcho: honcho, filters: filters, setFilters: setFilters, refresh: refresh, loading: loading })
+        ) : null,
+        showMnemosyne ? e(React.Fragment, null,
+          e(Separator, null),
+          e(MnemosyneSection, { mnemosyne: mnemosyne })
         ) : null,
         showHindsight ? e(React.Fragment, null,
           e(Separator, null),

--- a/dashboard/dist/style.css
+++ b/dashboard/dist/style.css
@@ -240,7 +240,12 @@
   grid-template-columns: minmax(220px, 1fr) minmax(130px, 0.24fr) auto;
 }
 
+.memory-ui-provider-controls {
+  grid-template-columns: minmax(220px, 1fr) minmax(110px, 0.2fr) minmax(110px, 0.2fr) auto;
+}
+
 .memory-ui-hindsight-actions,
+.memory-ui-provider-actions,
 .memory-ui-contents-toolbar {
   display: flex;
   align-items: center;
@@ -249,6 +254,11 @@
 
 .memory-ui-hindsight-actions {
   justify-content: flex-end;
+}
+
+.memory-ui-provider-actions {
+  justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .memory-ui-contents-toolbar {
@@ -262,6 +272,10 @@
   }
 
   .memory-ui-hindsight-actions {
+    justify-content: flex-start;
+  }
+
+  .memory-ui-provider-actions {
     justify-content: flex-start;
   }
 }

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "hermes-memory-ui",
   "label": "Memory",
-  "description": "Read-only Hermes dashboard plugin for built-in, holographic, Mem0, Honcho, and Hindsight memory.",
+  "description": "Read-only Hermes dashboard plugin for built-in, holographic, Mem0, Honcho, Mnemosyne, and Hindsight memory.",
   "icon": "Database",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "tab": {
     "path": "/memory",
     "position": "after:config"

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -11,6 +11,7 @@ and provider-specific semantics are preserved.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import os
 import sqlite3
@@ -33,6 +34,7 @@ except Exception:  # Allows local syntax/import tests outside the dashboard.
 
 router = APIRouter()
 
+PLUGIN_VERSION = "0.4.7"
 ENTRY_DELIMITER = "\n§\n"
 DEFAULT_MEMORY_LIMIT = 2200
 DEFAULT_USER_LIMIT = 1375
@@ -44,6 +46,8 @@ DEFAULT_HONCHO_LIMIT = 50
 MAX_HONCHO_LIMIT = 100
 DEFAULT_HINDSIGHT_LIMIT = 25
 MAX_HINDSIGHT_LIMIT = 100
+DEFAULT_MNEMOSYNE_LIMIT = 25
+MAX_MNEMOSYNE_LIMIT = 100
 HINDSIGHT_DEFAULT_CLOUD_URL = "https://api.hindsight.vectorize.io"
 HINDSIGHT_DEFAULT_LOCAL_URL = "http://localhost:8888"
 VALID_HINDSIGHT_BUDGETS = {"low", "mid", "high"}
@@ -596,7 +600,7 @@ def _honcho_config_payload(config: Optional[Dict[str, Any]] = None) -> Dict[str,
             "_client_config": cfg,
         })
     except Exception as exc:
-        base["_import_error"] = str(exc)
+        base["_import_error"] = f"Honcho provider helpers unavailable: {exc}"
     return base
 
 
@@ -760,6 +764,496 @@ def _honcho_payload(
     return base
 
 
+def _resolve_mnemosyne_data_dir(config: Dict[str, Any]) -> Path:
+    memory_cfg = config.get("memory", {}) if isinstance(config.get("memory"), dict) else {}
+    mnemosyne_cfg = memory_cfg.get("mnemosyne", {}) if isinstance(memory_cfg.get("mnemosyne"), dict) else {}
+    configured = (
+        mnemosyne_cfg.get("data_dir")
+        or mnemosyne_cfg.get("path")
+        or _env_value("MNEMOSYNE_DATA_DIR", "")
+        or str(_hermes_home() / "mnemosyne" / "data")
+    )
+    return _expand_path(str(configured), _hermes_home()) or (_hermes_home() / "mnemosyne" / "data")
+
+
+def _resolve_mnemosyne_db_path(config: Dict[str, Any]) -> Path:
+    memory_cfg = config.get("memory", {}) if isinstance(config.get("memory"), dict) else {}
+    mnemosyne_cfg = memory_cfg.get("mnemosyne", {}) if isinstance(memory_cfg.get("mnemosyne"), dict) else {}
+    configured = mnemosyne_cfg.get("db_path") or _env_value("MNEMOSYNE_DB_PATH", "")
+    if configured:
+        path = _expand_path(str(configured), _hermes_home())
+        if path:
+            return path
+    return _resolve_mnemosyne_data_dir(config) / "mnemosyne.db"
+
+
+def _load_mnemosyne_config(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    config = config if config is not None else _read_yaml(_hermes_home() / "config.yaml")
+    data_dir = _resolve_mnemosyne_data_dir(config)
+    db_path = _resolve_mnemosyne_db_path(config)
+    prefetch_chars = _env_value("MNEMOSYNE_PREFETCH_CONTENT_CHARS", "")
+    return {
+        "provider_configured": _dig(config, "memory", "provider", default=None) == "mnemosyne",
+        "config_path": str(_hermes_home() / "config.yaml"),
+        "data_dir": str(data_dir),
+        "db_path": str(db_path),
+        "db_exists": db_path.exists(),
+        "prefetch_content_chars": prefetch_chars,
+        "auto_sleep_enabled": _truthy(_env_value("MNEMOSYNE_AUTO_SLEEP_ENABLED", "true"), True),
+    }
+
+
+def _mnemosyne_table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        return conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ? LIMIT 1",
+            (table,),
+        ).fetchone() is not None
+    except Exception:
+        return False
+
+
+def _mnemosyne_table_count(conn: sqlite3.Connection, table: str) -> int:
+    if not _mnemosyne_table_exists(conn, table):
+        return 0
+    try:
+        quoted = table.replace('"', '""')
+        return int(conn.execute(f'SELECT COUNT(*) FROM "{quoted}"').fetchone()[0])
+    except Exception:
+        return 0
+
+
+def _mnemosyne_columns(conn: sqlite3.Connection, table: str) -> List[str]:
+    try:
+        quoted = table.replace('"', '""')
+        return [str(row["name"]) for row in conn.execute(f'PRAGMA table_info("{quoted}")').fetchall()]
+    except Exception:
+        return []
+
+
+def _json_object(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return {}
+    try:
+        parsed = json.loads(value)
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _mnemosyne_order_clause(columns: List[str], preferred: List[str]) -> str:
+    for column in preferred:
+        if column in columns:
+            quoted = column.replace('"', '""')
+            return f'ORDER BY "{quoted}" DESC'
+    return ""
+
+
+def _mnemosyne_where(search: Optional[str], columns: List[str], candidates: List[str]) -> tuple[str, List[Any]]:
+    if not search:
+        return "", []
+    available = [column for column in candidates if column in columns]
+    if not available:
+        return "", []
+    where = "WHERE " + " OR ".join([f'"{column.replace(chr(34), chr(34) + chr(34))}" LIKE ?' for column in available])
+    return where, [_safe_like(search)] * len(available)
+
+
+def _normalize_mnemosyne_memory(row: Dict[str, Any], index: int) -> Dict[str, Any]:
+    metadata = _json_object(row.get("metadata_json"))
+    text = row.get("content") or row.get("text") or row.get("memory") or ""
+    return {
+        "id": row.get("id") or row.get("rowid") or str(index + 1),
+        "text": str(text),
+        "score": row.get("score"),
+        "type": row.get("memory_type") or row.get("source") or "memory",
+        "source": row.get("source") or "",
+        "timestamp": row.get("timestamp"),
+        "created_at": row.get("created_at"),
+        "session_id": row.get("session_id"),
+        "importance": row.get("importance"),
+        "tier": row.get("tier"),
+        "recall_count": row.get("recall_count"),
+        "last_recalled": row.get("last_recalled"),
+        "scope": row.get("scope"),
+        "channel_id": row.get("channel_id"),
+        "trust_tier": row.get("trust_tier"),
+        "metadata": _json_safe(metadata),
+    }
+
+
+def _mnemosyne_fact_text(table: str, row: Dict[str, Any]) -> str:
+    if table == "memoria_facts":
+        key = str(row.get("key") or "").strip()
+        value = str(row.get("value") or "").strip()
+        if key and value:
+            return f"{key}: {value}"
+        return value or key or str(row.get("context_snippet") or "")
+    if table == "memoria_instructions":
+        return str(row.get("instruction") or "")
+    if table == "memoria_preferences":
+        return str(row.get("preference") or "")
+    if table == "memoria_timelines":
+        return str(row.get("description") or "")
+    if table == "memoria_kg":
+        return " ".join(str(row.get(key) or "") for key in ("subject", "predicate", "object")).strip()
+    if table == "triples":
+        return " ".join(str(row.get(key) or "") for key in ("subject", "predicate", "object")).strip()
+    if table == "gists":
+        return str(row.get("text") or "")
+    if table == "consolidated_facts":
+        return " ".join(str(row.get(key) or "") for key in ("subject", "predicate", "object")).strip()
+    if table == "facts":
+        return " ".join(str(row.get(key) or "") for key in ("subject", "predicate", "object")).strip()
+    return str(row.get("content") or row.get("value") or row.get("text") or "")
+
+
+def _normalize_mnemosyne_fact(table: str, row: Dict[str, Any], index: int) -> Dict[str, Any]:
+    row_id = row.get("id") or row.get("fact_id") or row.get("event_id") or str(index + 1)
+    timestamp = row.get("timestamp") or row.get("date") or row.get("created_at")
+    metadata = {
+        key: value
+        for key, value in row.items()
+        if key not in {"id", "fact_id", "event_id", "content", "text", "value"}
+    }
+    return {
+        "id": row_id,
+        "text": _mnemosyne_fact_text(table, row),
+        "score": row.get("importance") or row.get("confidence"),
+        "type": table,
+        "source": row.get("source") or row.get("session_id") or "",
+        "timestamp": timestamp,
+        "created_at": row.get("created_at"),
+        "metadata": _json_safe(metadata),
+    }
+
+
+def _mnemosyne_fetch_memories(
+    conn: sqlite3.Connection,
+    *,
+    limit: int,
+    search: Optional[str],
+) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for table in ("episodic_memory", "working_memory", "memories"):
+        if len(rows) >= limit or not _mnemosyne_table_exists(conn, table):
+            continue
+        columns = _mnemosyne_columns(conn, table)
+        selected = [
+            column
+            for column in (
+                "rowid",
+                "id",
+                "content",
+                "source",
+                "timestamp",
+                "session_id",
+                "importance",
+                "metadata_json",
+                "created_at",
+                "tier",
+                "memory_type",
+                "recall_count",
+                "last_recalled",
+                "scope",
+                "channel_id",
+                "trust_tier",
+            )
+            if column in columns
+        ]
+        if not selected:
+            continue
+        where, params = _mnemosyne_where(search, columns, ["content", "source", "session_id", "metadata_json"])
+        order = _mnemosyne_order_clause(columns, ["timestamp", "created_at", "rowid", "id"])
+        quoted_table = table.replace('"', '""')
+        quoted_columns = ", ".join(f'"{column.replace(chr(34), chr(34) + chr(34))}"' for column in selected)
+        sql = f'SELECT {quoted_columns} FROM "{quoted_table}" {where} {order} LIMIT ?'
+        try:
+            fetched = [dict(row) for row in conn.execute(sql, params + [limit - len(rows)]).fetchall()]
+        except Exception:
+            fetched = []
+        rows.extend(fetched)
+    return [_normalize_mnemosyne_memory(row, index) for index, row in enumerate(rows[:limit])]
+
+
+def _mnemosyne_fetch_facts(
+    conn: sqlite3.Connection,
+    *,
+    limit: int,
+    search: Optional[str],
+) -> List[Dict[str, Any]]:
+    specs = [
+        ("memoria_facts", ["id", "session_id", "fact_type", "key", "value", "context_snippet", "importance", "timestamp"], ["key", "value", "context_snippet"]),
+        ("memoria_instructions", ["id", "session_id", "instruction", "active", "topic", "context_snippet"], ["instruction", "topic", "context_snippet"]),
+        ("memoria_preferences", ["id", "session_id", "preference", "topic", "evolution", "context_snippet"], ["preference", "topic", "context_snippet"]),
+        ("memoria_timelines", ["event_id", "session_id", "date", "description", "source"], ["description", "source", "date"]),
+        ("memoria_kg", ["id", "session_id", "subject", "predicate", "object", "confidence"], ["subject", "predicate", "object"]),
+        ("triples", ["id", "subject", "predicate", "object", "valid_from", "source", "confidence", "created_at"], ["subject", "predicate", "object", "source"]),
+        ("gists", ["id", "text", "timestamp", "participants_json", "location", "emotion", "time_scope", "memory_id", "created_at"], ["text", "participants_json", "location", "emotion"]),
+        ("consolidated_facts", ["id", "subject", "predicate", "object", "confidence", "mention_count", "first_seen", "last_seen", "veracity"], ["subject", "predicate", "object"]),
+        ("facts", ["fact_id", "session_id", "subject", "predicate", "object", "timestamp", "confidence", "created_at"], ["subject", "predicate", "object"]),
+    ]
+    rows: List[tuple[str, Dict[str, Any]]] = []
+    for table, desired, search_columns in specs:
+        if len(rows) >= limit or not _mnemosyne_table_exists(conn, table):
+            continue
+        columns = _mnemosyne_columns(conn, table)
+        selected = [column for column in desired if column in columns]
+        if not selected:
+            continue
+        where, params = _mnemosyne_where(search, columns, search_columns)
+        order = _mnemosyne_order_clause(columns, ["timestamp", "date", "created_at", "id", "event_id", "fact_id"])
+        quoted_table = table.replace('"', '""')
+        quoted_columns = ", ".join(f'"{column.replace(chr(34), chr(34) + chr(34))}"' for column in selected)
+        sql = f'SELECT {quoted_columns} FROM "{quoted_table}" {where} {order} LIMIT ?'
+        try:
+            fetched = [dict(row) for row in conn.execute(sql, params + [limit - len(rows)]).fetchall()]
+        except Exception:
+            fetched = []
+        rows.extend((table, row) for row in fetched)
+    return [_normalize_mnemosyne_fact(table, row, index) for index, (table, row) in enumerate(rows[:limit])]
+
+
+def _mnemosyne_config_payload(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    cfg = _load_mnemosyne_config(config)
+    cfg.update({
+        "id": "mnemosyne",
+        "label": "Mnemosyne memory",
+        "mode": "read-only/query-only",
+        "error": None,
+        "generated_at": time.time(),
+    })
+    return cfg
+
+
+def _mnemosyne_contents_payload(
+    config: Optional[Dict[str, Any]] = None,
+    *,
+    limit: int = DEFAULT_MNEMOSYNE_LIMIT,
+    search: Optional[str] = None,
+) -> Dict[str, Any]:
+    config = config if config is not None else _read_yaml(_hermes_home() / "config.yaml")
+    try:
+        limit = int(limit or DEFAULT_MNEMOSYNE_LIMIT)
+    except Exception:
+        limit = DEFAULT_MNEMOSYNE_LIMIT
+    limit = max(1, min(limit, MAX_MNEMOSYNE_LIMIT))
+    search = search if isinstance(search, str) and search.strip() else None
+    base = _mnemosyne_config_payload(config)
+    base.update({
+        "operation": "contents",
+        "limit": limit,
+        "search": search or "",
+        "table_counts": {},
+        "memories": [],
+        "memory_count": 0,
+        "total_memories": 0,
+        "facts": [],
+        "fact_count": 0,
+        "total_facts": 0,
+        "vector_rows": 0,
+    })
+    db_path = Path(str(base["db_path"]))
+    if not db_path.exists():
+        return base
+    try:
+        with _connect_readonly(db_path) as conn:
+            count_tables = [
+                "episodic_memory",
+                "working_memory",
+                "memories",
+                "memoria_facts",
+                "memoria_instructions",
+                "memoria_preferences",
+                "memoria_timelines",
+                "memoria_kg",
+                "gists",
+                "triples",
+                "consolidated_facts",
+                "facts",
+                "scratchpad",
+                "vec_episodes_rowids",
+                "vec_facts_rowids",
+            ]
+            counts = {table: _mnemosyne_table_count(conn, table) for table in count_tables}
+            base["table_counts"] = counts
+            base["total_memories"] = counts.get("episodic_memory", 0) + counts.get("working_memory", 0) + counts.get("memories", 0)
+            base["total_facts"] = (
+                counts.get("memoria_facts", 0)
+                + counts.get("memoria_instructions", 0)
+                + counts.get("memoria_preferences", 0)
+                + counts.get("memoria_timelines", 0)
+                + counts.get("memoria_kg", 0)
+                + counts.get("gists", 0)
+                + counts.get("triples", 0)
+                + counts.get("consolidated_facts", 0)
+                + counts.get("facts", 0)
+            )
+            base["vector_rows"] = counts.get("vec_episodes_rowids", 0) + counts.get("vec_facts_rowids", 0)
+            base["memories"] = _mnemosyne_fetch_memories(conn, limit=limit, search=search)
+            base["memory_count"] = len(base["memories"])
+            base["facts"] = _mnemosyne_fetch_facts(conn, limit=limit, search=search)
+            base["fact_count"] = len(base["facts"])
+    except Exception as exc:
+        base["error"] = str(exc)
+    return base
+
+
+def _load_mnemosyne_provider_class() -> Any:
+    errors: List[str] = []
+    try:
+        from plugins.memory.mnemosyne import MnemosyneMemoryProvider  # type: ignore
+
+        return MnemosyneMemoryProvider
+    except Exception as exc:
+        errors.append(f"plugins.memory.mnemosyne: {exc}")
+
+    plugin_file = _hermes_home() / "plugins" / "mnemosyne" / "__init__.py"
+    if plugin_file.exists():
+        try:
+            spec = importlib.util.spec_from_file_location("hermes_memory_ui_mnemosyne_plugin", plugin_file)
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                provider_cls = getattr(module, "MnemosyneMemoryProvider", None)
+                if provider_cls is not None:
+                    return provider_cls
+        except Exception as exc:
+            errors.append(f"{plugin_file}: {exc}")
+
+    try:
+        from hermes_memory_provider import MnemosyneMemoryProvider  # type: ignore
+
+        return MnemosyneMemoryProvider
+    except Exception as exc:
+        errors.append(f"hermes_memory_provider: {exc}")
+
+    raise RuntimeError("Mnemosyne provider is not available in the dashboard environment: " + "; ".join(errors))
+
+
+def _make_mnemosyne_provider() -> Any:
+    provider_cls = _load_mnemosyne_provider_class()
+    provider = provider_cls()
+    provider.initialize(session_id="dashboard", hermes_home=str(_hermes_home()), platform="dashboard")
+    return provider
+
+
+def _decode_mnemosyne_response(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+            if isinstance(parsed, list):
+                return {"results": parsed}
+        except Exception:
+            return {"context": value}
+    return {"result": _json_safe(value)}
+
+
+def _normalize_mnemosyne_result(item: Any, index: int) -> Dict[str, Any]:
+    data = _object_to_dict(item)
+    if not data and isinstance(item, str):
+        data = {"content": item}
+    text = data.get("content") or data.get("text") or data.get("memory") or data.get("summary") or ""
+    metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else data.get("metadata_json")
+    return {
+        "id": data.get("id") or data.get("memory_id") or data.get("uuid") or str(index + 1),
+        "text": str(text),
+        "score": data.get("score") or data.get("similarity") or data.get("importance"),
+        "type": data.get("memory_type") or data.get("type") or data.get("source") or "memory",
+        "source": data.get("source") or "",
+        "timestamp": data.get("timestamp") or data.get("created_at"),
+        "metadata": _json_safe(_json_object(metadata) if isinstance(metadata, str) else (metadata if isinstance(metadata, dict) else {})),
+    }
+
+
+def _mnemosyne_payload(
+    config: Optional[Dict[str, Any]] = None,
+    *,
+    query: Optional[str] = None,
+    limit: int = DEFAULT_MNEMOSYNE_LIMIT,
+    temporal_weight: float = 0.2,
+    mode: str = "status",
+) -> Dict[str, Any]:
+    config = config if config is not None else _read_yaml(_hermes_home() / "config.yaml")
+    query = query if isinstance(query, str) and query.strip() else None
+    try:
+        limit = int(limit or DEFAULT_MNEMOSYNE_LIMIT)
+    except Exception:
+        limit = DEFAULT_MNEMOSYNE_LIMIT
+    limit = max(1, min(limit, MAX_MNEMOSYNE_LIMIT))
+    try:
+        temporal_weight = float(temporal_weight)
+    except Exception:
+        temporal_weight = 0.2
+    temporal_weight = max(0.0, min(1.0, temporal_weight))
+    base = _mnemosyne_config_payload(config)
+    base.update({
+        "operation": mode,
+        "query": query or "",
+        "limit": limit,
+        "temporal_weight": temporal_weight,
+        "results": [],
+        "result_count": 0,
+        "context": "",
+        "context_char_count": 0,
+        "result_source": "",
+    })
+    if mode == "status":
+        return base
+    if mode not in {"recall", "prefetch"}:
+        base["error"] = f"Unsupported Mnemosyne operation: {mode}"
+        return base
+    if not query:
+        base["error"] = "Query is required for Mnemosyne recall/prefetch."
+        return base
+    provider = None
+    try:
+        provider = _make_mnemosyne_provider()
+        if mode == "prefetch":
+            try:
+                context = provider.prefetch(query, session_id="dashboard")
+            except TypeError:
+                context = provider.prefetch(query)
+            base["context"] = str(context or "")
+            base["context_char_count"] = len(base["context"])
+            base["result_source"] = "mnemosyne_prefetch"
+            return base
+        response = provider.handle_tool_call(
+            "mnemosyne_recall",
+            {"query": query, "limit": limit, "temporal_weight": temporal_weight},
+        )
+        decoded = _decode_mnemosyne_response(response)
+        if decoded.get("error"):
+            base["error"] = str(decoded.get("error"))
+        raw_results = decoded.get("results") or decoded.get("memories") or decoded.get("matches") or []
+        if isinstance(raw_results, dict):
+            raw_results = list(raw_results.values())
+        if not isinstance(raw_results, list):
+            raw_results = []
+        base["results"] = [_normalize_mnemosyne_result(item, index) for index, item in enumerate(raw_results[:limit])]
+        base["result_count"] = len(base["results"])
+        base["result_source"] = "mnemosyne_recall"
+    except Exception as exc:
+        base["error"] = str(exc)
+    finally:
+        shutdown = getattr(provider, "shutdown", None) if provider is not None else None
+        if callable(shutdown):
+            try:
+                import contextlib
+                import io
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                    shutdown()
+            except Exception:
+                pass
+    return base
+
+
 def _load_hindsight_config(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Load non-secret Hindsight configuration for dashboard inspection."""
     config = config if config is not None else _read_yaml(_hermes_home() / "config.yaml")
@@ -916,7 +1410,7 @@ def _hindsight_client_call(cfg: Dict[str, Any], fn: Callable[[Any], Any]) -> Any
             base_url=str(cfg.get("api_url") or HINDSIGHT_DEFAULT_LOCAL_URL).rstrip("/"),
             api_key=cfg.get("_api_key") or None,
             timeout=_hindsight_timeout_seconds(cfg),
-            user_agent="hermes-memory-ui-dashboard/0.4.6",
+            user_agent=f"hermes-memory-ui-dashboard/{PLUGIN_VERSION}",
         )
         try:
             return await fn(client)
@@ -1156,10 +1650,11 @@ async def status() -> Dict[str, Any]:
     db_path = _resolve_holographic_db(config)
     mem0_cfg = _load_mem0_config(config)
     honcho_cfg = _honcho_config_payload(config)
+    mnemosyne_cfg = _load_mnemosyne_config(config)
     hindsight_cfg = _load_hindsight_config(config)
     return {
         "plugin": "hermes-memory-ui",
-        "version": "0.4.6",
+        "version": PLUGIN_VERSION,
         "mode": "read-only",
         "hermes_home": str(home),
         "config_path": str(home / "config.yaml"),
@@ -1196,6 +1691,15 @@ async def status() -> Dict[str, Any]:
             "recall_mode": honcho_cfg["recall_mode"],
             "session_strategy": honcho_cfg["session_strategy"],
             "provider_configured": _dig(config, "memory", "provider", default=None) == "honcho",
+        },
+        "mnemosyne": {
+            "config_path": mnemosyne_cfg["config_path"],
+            "data_dir": mnemosyne_cfg["data_dir"],
+            "db_path": mnemosyne_cfg["db_path"],
+            "db_exists": mnemosyne_cfg["db_exists"],
+            "prefetch_content_chars": mnemosyne_cfg["prefetch_content_chars"],
+            "auto_sleep_enabled": mnemosyne_cfg["auto_sleep_enabled"],
+            "provider_configured": mnemosyne_cfg["provider_configured"],
         },
         "hindsight": {
             "config_path": hindsight_cfg["config_path"],
@@ -1277,6 +1781,35 @@ async def hindsight_reflect(
     return _hindsight_payload(query=query, limit=1, mode="reflect")
 
 
+@router.get("/mnemosyne")
+async def mnemosyne() -> Dict[str, Any]:
+    return _mnemosyne_contents_payload()
+
+
+@router.get("/mnemosyne/contents")
+async def mnemosyne_contents(
+    limit: int = Query(DEFAULT_MNEMOSYNE_LIMIT, ge=1, le=MAX_MNEMOSYNE_LIMIT),
+    search: Optional[str] = Query(None),
+) -> Dict[str, Any]:
+    return _mnemosyne_contents_payload(limit=limit, search=search or None)
+
+
+@router.get("/mnemosyne/recall")
+async def mnemosyne_recall(
+    query: str = Query(...),
+    limit: int = Query(DEFAULT_MNEMOSYNE_LIMIT, ge=1, le=MAX_MNEMOSYNE_LIMIT),
+    temporal_weight: float = Query(0.2, ge=0.0, le=1.0),
+) -> Dict[str, Any]:
+    return _mnemosyne_payload(query=query, limit=limit, temporal_weight=temporal_weight, mode="recall")
+
+
+@router.get("/mnemosyne/prefetch")
+async def mnemosyne_prefetch(
+    query: str = Query(...),
+) -> Dict[str, Any]:
+    return _mnemosyne_payload(query=query, mode="prefetch")
+
+
 @router.get("/snapshot")
 async def snapshot(
     limit: int = Query(DEFAULT_FACT_LIMIT, ge=1, le=MAX_FACT_LIMIT),
@@ -1287,7 +1820,7 @@ async def snapshot(
     config = _read_yaml(_hermes_home() / "config.yaml")
     return {
         "plugin": "hermes-memory-ui",
-        "version": "0.4.6",
+        "version": PLUGIN_VERSION,
         "mode": "read-only",
         "builtin": _builtin_payload(config),
         "holographic": _holographic_payload(
@@ -1299,6 +1832,7 @@ async def snapshot(
         ),
         "mem0": _mem0_payload(config, limit=limit, search=search or None),
         "honcho": _honcho_payload(config, limit=limit, search=search or None),
+        "mnemosyne": _mnemosyne_contents_payload(config, limit=limit, search=search or None),
         "hindsight": _hindsight_payload(config, mode="status"),
         "generated_at": time.time(),
     }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 manifest_version: 1
 name: hermes-memory-ui
-version: 0.4.6
-description: "Read-only Hermes dashboard plugin for inspecting built-in, holographic, Mem0, Honcho, and Hindsight memory."
+version: 0.4.7
+description: "Read-only Hermes dashboard plugin for inspecting built-in, holographic, Mem0, Honcho, Mnemosyne, and Hindsight memory."
 homepage: "https://github.com/xraysight/hermes-memory-ui"

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import sqlite3
 import sys
 import types
 from pathlib import Path
@@ -10,6 +11,9 @@ PLUGIN_API = Path(__file__).resolve().parents[1] / "dashboard" / "plugin_api.py"
 
 def load_plugin_api(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    fake_constants = types.ModuleType("hermes_constants")
+    fake_constants.get_hermes_home = lambda: str(tmp_path)
+    monkeypatch.setitem(sys.modules, "hermes_constants", fake_constants)
     spec = importlib.util.spec_from_file_location("plugin_api_under_test", PLUGIN_API)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -424,3 +428,154 @@ def test_hindsight_recall_does_not_fall_back_to_documents(monkeypatch, tmp_path)
     assert payload["result_count"] == 0
     assert payload["results"] == []
     assert "secret" not in json.dumps(payload)
+
+
+def create_mnemosyne_db(tmp_path):
+    db_dir = tmp_path / "mnemosyne" / "data"
+    db_dir.mkdir(parents=True)
+    db_path = db_dir / "mnemosyne.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE episodic_memory (
+            rowid INTEGER,
+            id TEXT,
+            content TEXT,
+            source TEXT,
+            timestamp TEXT,
+            session_id TEXT,
+            importance REAL,
+            metadata_json TEXT,
+            created_at TEXT,
+            tier INTEGER,
+            memory_type TEXT,
+            recall_count INTEGER,
+            trust_tier TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO episodic_memory
+        VALUES (1, 'm1', 'Mnemosyne dashboard memory about recall quality', 'test', '2026-05-20T10:00:00Z',
+                's1', 0.9, '{"topic":"dashboard"}', '2026-05-20T10:00:00Z', 1, 'experience', 2, 'STATED')
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE memoria_facts (
+            id INTEGER,
+            session_id TEXT,
+            fact_type TEXT,
+            key TEXT,
+            value TEXT,
+            context_snippet TEXT,
+            importance REAL,
+            timestamp TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO memoria_facts
+        VALUES (1, 's1', 'preference', 'memory_provider', 'mnemosyne',
+                'dashboard should show Mnemosyne facts', 0.8, '2026-05-20T10:00:01Z')
+        """
+    )
+    conn.execute("CREATE TABLE vec_episodes_rowids (rowid INTEGER, id TEXT, chunk_id INTEGER, chunk_offset INTEGER)")
+    conn.execute("INSERT INTO vec_episodes_rowids VALUES (1, 'm1', 1, 0)")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def install_fake_mnemosyne_provider(monkeypatch, calls):
+    fake_plugins = types.ModuleType("plugins")
+    fake_memory = types.ModuleType("plugins.memory")
+    fake_mnemosyne = types.ModuleType("plugins.memory.mnemosyne")
+
+    class FakeProvider:
+        def initialize(self, session_id, **kwargs):
+            calls.append(("initialize", session_id, kwargs))
+
+        def handle_tool_call(self, tool_name, args, **kwargs):
+            calls.append(("handle_tool_call", tool_name, args, kwargs))
+            return json.dumps({
+                "query": args["query"],
+                "count": 1,
+                "results": [{
+                    "id": "r1",
+                    "content": "Mnemosyne recall result",
+                    "score": 0.93,
+                    "source": "episodic_memory",
+                    "metadata": {"scope": "dashboard"},
+                }],
+            })
+
+        def prefetch(self, query, session_id=""):
+            calls.append(("prefetch", query, session_id))
+            return "Injected Mnemosyne context for " + query
+
+        def shutdown(self):
+            calls.append(("shutdown",))
+
+    fake_mnemosyne.MnemosyneMemoryProvider = FakeProvider
+    monkeypatch.setitem(sys.modules, "plugins", fake_plugins)
+    monkeypatch.setitem(sys.modules, "plugins.memory", fake_memory)
+    monkeypatch.setitem(sys.modules, "plugins.memory.mnemosyne", fake_mnemosyne)
+
+
+def test_mnemosyne_contents_reads_local_db_without_writes(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: mnemosyne\n", encoding="utf-8")
+    db_path = create_mnemosyne_db(tmp_path)
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    payload = module._mnemosyne_contents_payload(limit=5, search="dashboard")
+
+    assert payload["provider_configured"] is True
+    assert payload["db_path"] == str(db_path)
+    assert payload["db_exists"] is True
+    assert payload["table_counts"]["episodic_memory"] == 1
+    assert payload["total_memories"] == 1
+    assert payload["vector_rows"] == 1
+    assert payload["memory_count"] == 1
+    assert payload["memories"][0]["text"] == "Mnemosyne dashboard memory about recall quality"
+    assert payload["fact_count"] == 1
+    assert payload["facts"][0]["type"] == "memoria_facts"
+    assert payload["facts"][0]["text"] == "memory_provider: mnemosyne"
+
+
+def test_mnemosyne_recall_and_prefetch_use_provider_without_remember(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: mnemosyne\n", encoding="utf-8")
+    calls = []
+    install_fake_mnemosyne_provider(monkeypatch, calls)
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    recall = module._mnemosyne_payload(query="dashboard", limit=2, temporal_weight=0.5, mode="recall")
+    prefetch = module._mnemosyne_payload(query="dashboard", mode="prefetch")
+
+    assert recall["result_source"] == "mnemosyne_recall"
+    assert recall["result_count"] == 1
+    assert recall["results"][0]["text"] == "Mnemosyne recall result"
+    assert recall["results"][0]["score"] == 0.93
+    assert prefetch["result_source"] == "mnemosyne_prefetch"
+    assert prefetch["context"] == "Injected Mnemosyne context for dashboard"
+    assert ("handle_tool_call", "mnemosyne_recall", {"query": "dashboard", "limit": 2, "temporal_weight": 0.5}, {}) in calls
+    assert ("prefetch", "dashboard", "dashboard") in calls
+    assert not any(call and call[0] == "mnemosyne_remember" for call in calls)
+
+
+def test_mnemosyne_snapshot_and_status_include_provider(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: mnemosyne\n", encoding="utf-8")
+    create_mnemosyne_db(tmp_path)
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    import asyncio
+
+    snapshot = asyncio.run(module.snapshot(limit=5))
+    status = asyncio.run(module.status())
+
+    assert snapshot["mnemosyne"]["provider_configured"] is True
+    assert snapshot["mnemosyne"]["memory_count"] == 1
+    assert status["mnemosyne"]["provider_configured"] is True
+    assert status["mnemosyne"]["db_exists"] is True


### PR DESCRIPTION
## Summary
- adds read-only Mnemosyne status and local SQLite contents endpoints
- adds explicit Mnemosyne recall and prefetch/injected-context preview endpoints without exposing write tools
- adds a Mnemosyne dashboard section, provider stats, docs, manifest/version updates, and pytest coverage

## Verification
- uvx --with pyyaml pytest tests/test_plugin_api.py -q
- python3 -m py_compile dashboard/plugin_api.py
- node --check dashboard/dist/index.js
- live Hermes dev dashboard: /memory showed Mnemosyne active with 4809 episodes / 3966 facts; Preview inject returned context; Recall returned mnemosyne_recall Gmail backstop results