### PR TITLE
fix: address ByteRover review feedback

### DIFF
--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -1747,6 +1747,40 @@ def _load_byterover_config(config: Optional[Dict[str, Any]] = None) -> Dict[str,
     }
 
 
+def _parse_byterover_json_output(raw: str) -> Any:
+    """Parse ByteRover JSON output, accepting both single JSON and JSON-lines events."""
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except Exception:
+        pass
+
+    events: List[Any] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except Exception:
+            return {"raw": raw}
+    if not events:
+        return {"raw": raw}
+
+    completed = None
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        marker = str(event.get("event") or event.get("status") or "").lower()
+        if marker == "completed":
+            completed = event
+    if isinstance(completed, dict):
+        data = completed.get("data") if isinstance(completed.get("data"), dict) else completed
+        return {"success": True, "data": data, "events": events}
+    return {"success": True, "data": events[-1] if isinstance(events[-1], dict) else {"events": events}, "events": events}
+
+
 def _run_byterover_command(cfg: Dict[str, Any], args: List[str], *, timeout: int = 30) -> Dict[str, Any]:
     brv = cfg.get("resolved_brv_path") or cfg.get("brv_path") or "brv"
     if not cfg.get("brv_available"):
@@ -1766,12 +1800,7 @@ def _run_byterover_command(cfg: Dict[str, Any], args: List[str], *, timeout: int
         return {"ok": False, "error": _safe_error(exc), "data": None}
 
     raw = (result.stdout or result.stderr or "").strip()
-    parsed: Any = None
-    if raw:
-        try:
-            parsed = json.loads(raw)
-        except Exception:
-            parsed = {"raw": raw}
+    parsed: Any = _parse_byterover_json_output(raw) if raw else None
     if result.returncode != 0:
         return {"ok": False, "error": _safe_error(raw or f"brv exited with {result.returncode}"), "data": parsed}
     if isinstance(parsed, dict) and parsed.get("success") is False:
@@ -1850,8 +1879,13 @@ def _normalize_byterover_result(item: Any, index: int, query: Optional[str] = No
             candidate = Path(project_root) / ".brv" / "context-tree" / str(path)
             resolved = candidate.resolve()
             root = (Path(project_root) / ".brv" / "context-tree").resolve()
-            if str(resolved).startswith(str(root)) and resolved.exists() and resolved.is_file():
-                full_text = resolved.read_text(encoding="utf-8", errors="replace")
+            if resolved.exists() and resolved.is_file():
+                try:
+                    resolved.relative_to(root)
+                except ValueError:
+                    full_text = ""
+                else:
+                    full_text = resolved.read_text(encoding="utf-8", errors="replace")
         except Exception:
             full_text = ""
     compact = _compact_byterover_excerpt(full_text or raw_text, query)
@@ -1976,7 +2010,6 @@ def _byterover_payload(
 
     status_args = ["status", "--format", "json"]
     if cfg.get("project_root"):
-        status_args.extend(["--project-root", str(cfg["project_root"])])
         status = _run_byterover_command(cfg, status_args, timeout=20)
         if status["ok"]:
             base["status"] = _json_safe(_unwrap_byterover_data(status["data"]))

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -688,7 +688,8 @@ def test_byterover_payload_uses_brv_status_locations_and_search(monkeypatch, tmp
     assert payload["results"][0]["score"] == 0.91
     calls = [json.loads(line)["argv"] for line in log_path.read_text(encoding="utf-8").splitlines()]
     assert ["locations", "--format", "json"] in calls
-    assert ["status", "--format", "json", "--project-root", str(project)] in calls
+    assert ["status", "--format", "json"] in calls
+    assert not any(call[:1] == ["status"] and "--project-root" in call for call in calls)
     assert ["search", "dashboard", "--format", "json", "--limit", "3", "--scope", "docs/"] in calls
 
 
@@ -716,6 +717,72 @@ def test_byterover_query_is_explicit_and_status_includes_provider(monkeypatch, t
     calls = [json.loads(line)["argv"] for line in log_path.read_text(encoding="utf-8").splitlines()]
     assert ["query", "What is memory UI?", "--format", "json"] in calls
 
+
+
+def test_byterover_query_parses_json_lines_completed_event(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    script = tmp_path / "fake-brv-jsonl"
+    log_path = tmp_path / "brv-jsonl-calls.jsonl"
+    script.write_text(
+        """#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+log = Path(os.environ.get('FAKE_BRV_LOG', ''))
+if log:
+    with log.open('a', encoding='utf-8') as fh:
+        fh.write(json.dumps({'argv': sys.argv[1:], 'cwd': os.getcwd()}) + '\\n')
+cmd = sys.argv[1] if len(sys.argv) > 1 else ''
+if cmd == 'locations':
+    print(json.dumps({'success': True, 'command': 'locations', 'data': {'locations': []}}))
+elif cmd == 'status':
+    print(json.dumps({'success': True, 'command': 'status', 'data': {'projectPath': os.getcwd(), 'isInitialized': True}}))
+elif cmd == 'query':
+    query = sys.argv[2]
+    print(json.dumps({'event': 'thinking', 'message': 'working'}))
+    print(json.dumps({'event': 'response', 'delta': 'partial'}))
+    print(json.dumps({'event': 'completed', 'result': 'JSONL answer about ' + query, 'matchedDocs': [{'path': 'docs/jsonl.md'}], 'taskId': 'jsonl-task', 'topScore': 0.77}))
+else:
+    print(json.dumps({'success': True, 'data': {}}))
+""",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    monkeypatch.setenv("FAKE_BRV_LOG", str(log_path))
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: byterover\n", encoding="utf-8")
+    (tmp_path / "byterover.json").write_text(json.dumps({"brv_path": str(script), "project_root": str(project)}), encoding="utf-8")
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    payload = module._byterover_query_payload("How does JSONL work?")
+
+    assert payload["error"] is None
+    assert payload["answer"] == "JSONL answer about How does JSONL work?"
+    assert payload["answer_summary"] == "JSONL answer about How does JSONL work?"
+    assert payload["matched_docs"] == [{"path": "docs/jsonl.md"}]
+    assert payload["task_id"] == "jsonl-task"
+    assert payload["top_score"] == 0.77
+
+
+def test_byterover_context_tree_excerpt_rejects_sibling_prefix_paths(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    context_root = project / ".brv" / "context-tree"
+    sibling_root = project / ".brv" / "context-tree2"
+    context_root.mkdir(parents=True)
+    sibling_root.mkdir(parents=True)
+    secret_file = sibling_root / "secret.md"
+    secret_file.write_text("SECRET outside context tree", encoding="utf-8")
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    result = module._normalize_byterover_result(
+        {"path": "../context-tree2/secret.md", "excerpt": "safe fallback excerpt"},
+        0,
+        "secret",
+        str(project),
+    )
+
+    dumped = json.dumps(result)
+    assert "SECRET outside context tree" not in dumped
+    assert result["excerpt"] == "safe fallback excerpt"
 
 
 def test_byterover_search_requires_project_root_to_avoid_creating_context(monkeypatch, tmp_path):


### PR DESCRIPTION
**Summary**
This is a follow-up to #4 addressing the automated Codex review feedback for the ByteRover dashboard integration.

**Changes**

- handle ByteRover JSON-lines query output by selecting the final completed event payload
- keep support for the existing single-JSON output shape
- fix .brv/context-tree file containment checks using real path ancestry instead of string-prefix matching
- remove redundant --project-root from brv status calls and rely on the configured project-root cwd
- add regression tests for all three cases


**Why**
Codex flagged three issues in #4:
1. brv query --format json may emit newline-delimited JSON events rather than one JSON document.
2. The previous path containment check used startswith, which could be bypassed by sibling prefixes such as .brv/context-tree2.
3. brv status --project-root ... may not be supported by older ByteRover CLI versions; since the subprocess already runs with cwd=project_root, the flag is unnecessary.
