### PR TITLE
fix: improve Hindsight local daemon handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,17 @@ Hindsight support follows Hermes' bundled `hindsight` memory provider convention
 
 - `$HERMES_HOME/hindsight/config.json`
 - legacy `~/.hindsight/config.json`
-- environment variables such as `HINDSIGHT_MODE`, `HINDSIGHT_API_URL`, `HINDSIGHT_BANK_ID`, and `HINDSIGHT_BUDGET`
+- environment variables such as `HINDSIGHT_MODE`, `HINDSIGHT_API_URL`, `HINDSIGHT_DAEMON_URL`, `HINDSIGHT_BANK_ID`, and `HINDSIGHT_BUDGET`
+
+The daemon/API endpoint is resolved with this precedence:
+
+```text
+hindsight/config.json api_url > HINDSIGHT_API_URL > HINDSIGHT_DAEMON_URL > default
+```
+
+For `local_embedded`, the default endpoint is `http://localhost:8888`. If the resolved endpoint is remote, for example `HINDSIGHT_DAEMON_URL=http://192.168.42.20:8888`, the dashboard treats that daemon as authoritative and does not try to start `hindsight-embed daemon start` on the dashboard host. Local daemon startup is attempted only for `localhost`, `127.0.0.1`, or `::1` endpoints.
+
+When local daemon startup is needed, the plugin resolves `hindsight-embed` from `PATH`, the current Python environment, Hermes' bundled venv under `$HERMES_HOME/hermes-agent/venv/bin`, the default `~/.hermes/hermes-agent/venv/bin`, or `~/.local/bin`. If the binary cannot be found, the error includes safe diagnostics for `PATH`, `sys.executable`, and checked paths.
 
 Secrets such as `HINDSIGHT_API_KEY` and `HINDSIGHT_LLM_API_KEY` are only detected as boolean `*_present` flags and are never returned in plugin responses. Hindsight is query-oriented rather than a complete list API, so the dashboard only calls recall/reflect after the user clicks a button. `/snapshot` and page load include status/config only.
 

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+import sys
 import threading
 import time
 import urllib.parse
@@ -1333,7 +1334,12 @@ def _load_hindsight_config(config: Optional[Dict[str, Any]] = None) -> Dict[str,
     api_key = file_cfg.get("apiKey") or file_cfg.get("api_key") or _env_value("HINDSIGHT_API_KEY", "")
     llm_key = file_cfg.get("llmApiKey") or file_cfg.get("llm_api_key") or _env_value("HINDSIGHT_LLM_API_KEY", "")
     default_url = HINDSIGHT_DEFAULT_LOCAL_URL if mode in {"local_embedded", "local_external"} else HINDSIGHT_DEFAULT_CLOUD_URL
-    api_url = file_cfg.get("api_url") or _env_value("HINDSIGHT_API_URL", default_url)
+    api_url = (
+        file_cfg.get("api_url")
+        or _env_value("HINDSIGHT_API_URL", "")
+        or _env_value("HINDSIGHT_DAEMON_URL", "")
+        or default_url
+    )
     banks = file_cfg.get("banks") if isinstance(file_cfg.get("banks"), dict) else {}
     hermes_bank = banks.get("hermes") if isinstance(banks.get("hermes"), dict) else {}
     bank_id = file_cfg.get("bank_id") or hermes_bank.get("bankId") or _env_value("HINDSIGHT_BANK_ID", "hermes")
@@ -1403,18 +1409,66 @@ def _hindsight_should_manage_local_daemon(cfg: Dict[str, Any]) -> bool:
     return parsed.hostname in {"127.0.0.1", "localhost", "::1"}
 
 
+def _hindsight_embed_candidates() -> List[Path]:
+    candidates: List[Path] = []
+    which = shutil.which("hindsight-embed")
+    if which:
+        candidates.append(Path(which))
+    try:
+        candidates.append(Path(sys.executable).with_name("hindsight-embed"))
+    except Exception:
+        pass
+    candidates.extend([
+        _hermes_home() / "hermes-agent" / "venv" / "bin" / "hindsight-embed",
+        Path.home() / ".hermes" / "hermes-agent" / "venv" / "bin" / "hindsight-embed",
+        Path.home() / ".local" / "bin" / "hindsight-embed",
+    ])
+
+    seen = set()
+    unique: List[Path] = []
+    for candidate in candidates:
+        text = str(candidate)
+        if text and text not in seen:
+            unique.append(candidate)
+            seen.add(text)
+    return unique
+
+
+def _resolve_hindsight_embed() -> tuple[Optional[str], Dict[str, Any]]:
+    candidates = _hindsight_embed_candidates()
+    checked = [str(path) for path in candidates]
+    resolved = None
+    for path in candidates:
+        if path.exists() and os.access(path, os.X_OK):
+            resolved = str(path)
+            break
+    diagnostics = {
+        "PATH": os.environ.get("PATH", ""),
+        "sys_executable": sys.executable,
+        "checked_paths": checked,
+        "resolved_path": resolved,
+    }
+    return resolved, diagnostics
+
+
 def _ensure_hindsight_local_daemon(cfg: Dict[str, Any]) -> Optional[str]:
     """Best-effort start for local_embedded Hindsight before client calls."""
     if not _hindsight_should_manage_local_daemon(cfg):
         return None
     profile = str(cfg.get("profile") or "hermes")
-    cmd = ["hindsight-embed", "-p", profile, "daemon", "start"]
+    binary, diagnostics = _resolve_hindsight_embed()
+    diagnostics.update({"profile": profile, "mode": cfg.get("mode")})
+    if not binary:
+        safe_diagnostics = _safe_error(json.dumps(diagnostics, sort_keys=True))
+        return f"hindsight-embed command not found in dashboard environment; diagnostics={safe_diagnostics}"
+    cmd = [binary, "-p", profile, "daemon", "start"]
     env = os.environ.copy()
     env.setdefault("HERMES_HOME", str(_hermes_home()))
     try:
         result = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=60)
     except FileNotFoundError:
-        return "hindsight-embed command not found in dashboard environment"
+        safe_diagnostics = _safe_error(json.dumps(diagnostics, sort_keys=True))
+        return f"hindsight-embed command not found in dashboard environment; diagnostics={safe_diagnostics}"
     except Exception as exc:
         return f"Could not start local Hindsight daemon: {_safe_error(exc)}"
     if result.returncode not in (0,):

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -326,6 +326,91 @@ def test_hindsight_config_status_hides_keys_and_reads_local_config(monkeypatch, 
     assert "llm-secret" not in dumped
 
 
+def test_hindsight_uses_daemon_url_for_split_host_without_managing_local_daemon(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: hindsight\n", encoding="utf-8")
+    cfg_path = tmp_path / "hindsight" / "config.json"
+    cfg_path.parent.mkdir()
+    cfg_path.write_text(json.dumps({"mode": "local_embedded"}), encoding="utf-8")
+    monkeypatch.setenv("HINDSIGHT_DAEMON_URL", "http://192.168.42.20:8888")
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    cfg = module._load_hindsight_config()
+
+    assert cfg["_api_url"] == "http://192.168.42.20:8888"
+    assert cfg["api_url"] == "http://192.168.42.20:8888"
+    assert module._hindsight_should_manage_local_daemon(cfg) is False
+    assert module._ensure_hindsight_local_daemon(cfg) is None
+
+
+def test_hindsight_endpoint_precedence_prefers_file_then_api_env_then_daemon_env(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: hindsight\n", encoding="utf-8")
+    cfg_path = tmp_path / "hindsight" / "config.json"
+    cfg_path.parent.mkdir()
+    cfg_path.write_text(json.dumps({"mode": "local_embedded"}), encoding="utf-8")
+    monkeypatch.setenv("HINDSIGHT_DAEMON_URL", "http://192.168.42.20:8888")
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    assert module._load_hindsight_config()["_api_url"] == "http://192.168.42.20:8888"
+
+    monkeypatch.setenv("HINDSIGHT_API_URL", "http://192.168.42.30:8888")
+    assert module._load_hindsight_config()["_api_url"] == "http://192.168.42.30:8888"
+
+    cfg_path.write_text(json.dumps({"mode": "local_embedded", "api_url": "http://192.168.42.40:8888"}), encoding="utf-8")
+    assert module._load_hindsight_config()["_api_url"] == "http://192.168.42.40:8888"
+
+
+def test_hindsight_local_daemon_uses_resolved_binary_when_path_is_constrained(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: hindsight\n", encoding="utf-8")
+    cfg_path = tmp_path / "hindsight" / "config.json"
+    cfg_path.parent.mkdir()
+    cfg_path.write_text(json.dumps({"mode": "local_embedded", "profile": "test-profile"}), encoding="utf-8")
+    fake_bin = tmp_path / "venv" / "bin"
+    fake_bin.mkdir(parents=True)
+    fake_executable = fake_bin / "python"
+    fake_executable.write_text("", encoding="utf-8")
+    fake_hindsight_embed = fake_bin / "hindsight-embed"
+    fake_hindsight_embed.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_hindsight_embed.chmod(0o755)
+    calls = []
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    monkeypatch.setattr(module.sys, "executable", str(fake_executable))
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    cfg = module._load_hindsight_config()
+
+    assert module._ensure_hindsight_local_daemon(cfg) is None
+    assert calls[0][0] == [str(fake_hindsight_embed), "-p", "test-profile", "daemon", "start"]
+
+
+def test_hindsight_local_daemon_reports_safe_diagnostics_when_binary_missing(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("memory:\n  provider: hindsight\n", encoding="utf-8")
+    cfg_path = tmp_path / "hindsight" / "config.json"
+    cfg_path.parent.mkdir()
+    cfg_path.write_text(json.dumps({"mode": "local_embedded"}), encoding="utf-8")
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    monkeypatch.setenv("PATH", "/nonexistent")
+    missing_python = tmp_path / "missing" / "python"
+    missing_binary = tmp_path / "missing" / "hindsight-embed"
+    monkeypatch.setattr(module.sys, "executable", str(missing_python))
+    monkeypatch.setattr(module, "_hindsight_embed_candidates", lambda: [missing_binary])
+    cfg = module._load_hindsight_config()
+
+    error = module._ensure_hindsight_local_daemon(cfg)
+
+    assert "hindsight-embed command not found" in error
+    assert "checked_paths" in error
+    assert str(missing_binary) in error
+    assert "api_key" not in error.lower()
+    assert "secret" not in error.lower()
+
+
 def test_hindsight_api_url_is_redacted_in_public_payloads(monkeypatch, tmp_path):
     (tmp_path / "config.yaml").write_text("memory:\n  provider: hindsight\n", encoding="utf-8")
     cfg_path = tmp_path / "hindsight" / "config.json"


### PR DESCRIPTION
Summary

Fixes both open Hindsight local_embedded issues.

Changes:
- resolves hindsight-embed from multiple locations instead of relying only on dashboard PATH
- supports HINDSIGHT_DAEMON_URL as a daemon/API endpoint fallback
- prevents local daemon startup when the resolved Hindsight endpoint is remote
- keeps local daemon management only for localhost, 127.0.0.1, or ::1
- adds safe missing-binary diagnostics without exposing secrets
- documents split-host behavior and endpoint precedence
- adds regression tests for resolver, endpoint precedence, remote daemon behavior, and safe diagnostics

Fixes #1
Fixes #2
