### PR TITLE
fix(honcho): show real conclusion totals in dashboard, not page size

### DIFF
--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -350,8 +350,8 @@
           e("div", { className: "memory-ui-muted" }, peer.peer_id || "—")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: "outline" }, card.length + " card facts"),
-          e(Badge, { variant: "outline" }, conclusions.length + " conclusions")
+          e(Badge, { variant: "outline" }, ((peer.total_card_facts != null ? peer.total_card_facts : card.length)) + " card facts"),
+          e(Badge, { variant: "outline" }, ((peer.total_conclusions != null ? peer.total_conclusions : conclusions.length)) + " conclusions" + (peer.total_conclusions != null && peer.total_conclusions > conclusions.length ? " (showing " + conclusions.length + " latest)" : ""))
         )
       ),
       e(CardContent, null,
@@ -935,7 +935,7 @@
             e(StatCard, { label: "Built-in entries", value: builtin ? builtin.total_entries : 0, hint: "MEMORY.md + USER.md" }),
             showHolographic ? e(StatCard, { label: "Facts", value: holographic ? holographic.total_facts : 0, hint: "holographic facts" }) : null,
             showMem0 ? e(StatCard, { label: "Mem0", value: mem0 ? mem0.total_memories : 0, hint: "Mem0 memories" }) : null,
-            showHoncho ? e(StatCard, { label: "Honcho", value: honcho ? ((honcho.user.card || []).length + (honcho.ai.card || []).length) : 0, hint: "peer card facts" }) : null,
+            showHoncho ? e(StatCard, { label: "Honcho", value: honcho ? (((honcho.user.total_conclusions != null ? honcho.user.total_conclusions : (honcho.user.conclusions || []).length)) + ((honcho.ai.total_conclusions != null ? honcho.ai.total_conclusions : (honcho.ai.conclusions || []).length))) : 0, hint: "total conclusions" }) : null,
             showMnemosyne ? e(StatCard, { label: "Mnemosyne", value: mnemosyne ? (mnemosyne.total_memories || 0) : 0, hint: "local episodes" }) : null,
             showByteRover ? e(StatCard, { label: "ByteRover", value: byterover && byterover.project_exists ? "active" : "configured", hint: "search/query memory" }) : null,
             showHindsight ? e(StatCard, { label: "Hindsight", value: hindsight ? (hindsight.bank_id || "active") : "—", hint: "query-only memory" }) : null,

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -23,7 +23,7 @@ import threading
 import time
 import urllib.parse
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
     from fastapi import APIRouter, Query
@@ -694,18 +694,43 @@ def _call_peer_context(peer_obj: Any, *, target: str, search: Optional[str], lim
     return {"representation": str(representation or ""), "card": card}
 
 
-def _list_honcho_conclusions(observer_peer: Any, target_peer_id: str, limit: int) -> List[Dict[str, Any]]:
+def _list_honcho_conclusions(
+    observer_peer: Any, target_peer_id: str, limit: int
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Return ``(newest-first conclusions, total count)``.
+
+    Honcho's Python SDK returns a ``SyncPage`` from
+    ``ConclusionScope.list(page, size)`` whose ``.total`` attribute reflects
+    the full population in the database, not just the current page. Surfacing
+    that total lets the dashboard show the real population (e.g. 2076)
+    instead of ``len(items)`` (which is bounded by ``MAX_HONCHO_LIMIT``).
+
+    Items are sorted newest-first defensively so the "showing N latest" hint
+    in the UI stays correct even if the SDK ever changes its default order.
+    """
     try:
         scope = observer_peer.conclusions_of(target_peer_id)
         try:
-            items = scope.list(page=1, size=limit, reverse=True)
+            page = scope.list(page=1, size=limit, reverse=True)
         except TypeError:
-            items = scope.list(page=1, size=limit)
-        if not isinstance(items, list):
-            items = list(items or [])
-        return [_normalize_honcho_conclusion(item, index) for index, item in enumerate(items[:limit])]
+            page = scope.list(page=1, size=limit)
+        if hasattr(page, "items") and hasattr(page, "total"):
+            raw_items = list(page.items or [])
+            total = int(getattr(page, "total", 0) or 0)
+        else:
+            raw_items = list(page or [])
+            total = len(raw_items)
+        normalized = [
+            _normalize_honcho_conclusion(item, index)
+            for index, item in enumerate(raw_items[:limit])
+        ]
+        try:
+            normalized.sort(key=lambda c: c.get("created_at") or "", reverse=True)
+        except Exception:
+            pass
+        return normalized, total
     except Exception:
-        return []
+        return [], 0
 
 
 def _honcho_search_results(base: Dict[str, Any], search: Optional[str], limit: int) -> List[Dict[str, Any]]:
@@ -787,8 +812,8 @@ def _honcho_payload(
         "ai_observe_me": honcho_cfg["ai_observe_me"],
         "ai_observe_others": honcho_cfg["ai_observe_others"],
         "explicitly_configured": honcho_cfg["explicitly_configured"],
-        "user": {"peer_id": honcho_cfg["user_peer"], "card": [], "representation": "", "conclusions": []},
-        "ai": {"peer_id": honcho_cfg["ai_peer"], "card": [], "representation": "", "conclusions": []},
+        "user": {"peer_id": honcho_cfg["user_peer"], "card": [], "representation": "", "conclusions": [], "total_conclusions": 0, "total_card_facts": 0},
+        "ai": {"peer_id": honcho_cfg["ai_peer"], "card": [], "representation": "", "conclusions": [], "total_conclusions": 0, "total_card_facts": 0},
         "search_results": [],
         "search_result_count": 0,
         "limit": limit,
@@ -813,8 +838,14 @@ def _honcho_payload(
         ai_peer_obj = client.peer(ai_peer_id)
         base["user"].update(_call_peer_context(user_peer_obj, target=user_peer_id, search=search, limit=limit))
         base["ai"].update(_call_peer_context(ai_peer_obj, target=ai_peer_id, search=search, limit=limit))
-        base["user"]["conclusions"] = _list_honcho_conclusions(ai_peer_obj, user_peer_id, limit)
-        base["ai"]["conclusions"] = _list_honcho_conclusions(ai_peer_obj, ai_peer_id, limit)
+        user_concs, user_total = _list_honcho_conclusions(ai_peer_obj, user_peer_id, limit)
+        ai_concs, ai_total = _list_honcho_conclusions(ai_peer_obj, ai_peer_id, limit)
+        base["user"]["conclusions"] = user_concs
+        base["user"]["total_conclusions"] = user_total
+        base["user"]["total_card_facts"] = len(base["user"].get("card") or [])
+        base["ai"]["conclusions"] = ai_concs
+        base["ai"]["total_conclusions"] = ai_total
+        base["ai"]["total_card_facts"] = len(base["ai"].get("card") or [])
         base["search_results"] = _honcho_search_results(base, search, limit)
         base["search_result_count"] = len(base["search_results"])
     except Exception as exc:

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -716,7 +716,9 @@ def _list_honcho_conclusions(
             page = scope.list(page=1, size=limit)
         if hasattr(page, "items") and hasattr(page, "total"):
             raw_items = list(page.items or [])
-            total = int(getattr(page, "total", 0) or 0)
+            # Fallback when total is missing or None — guard against
+            # backends that report 0/None despite having items.
+            total = int(getattr(page, "total", None) or len(raw_items))
         else:
             raw_items = list(page or [])
             total = len(raw_items)

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -194,6 +194,113 @@ def install_fake_honcho_client(monkeypatch, tmp_path, calls):
     monkeypatch.setitem(sys.modules, "plugins.memory.honcho.client", fake_client)
 
 
+# --- Regression tests for _list_honcho_conclusions -------------------------
+#
+# The dashboard used to render `len(conclusions)` as if it were the database
+# total. These tests pin the contract that:
+#   1. SyncPage-like objects with `.items` and `.total` surface `.total`.
+#   2. Plain-list fallback paths report `len(items)`.
+#   3. The function uses the page's items as-is and does not iterate or
+#      fetch additional pages (no surprise N+1 calls against the SDK).
+
+
+class _FakeSyncPage:
+    """Minimal stand-in for honcho.pagination.SyncPage."""
+
+    def __init__(self, items, total):
+        self.items = items
+        self.total = total
+
+
+def _make_observer_peer(returned_page, calls):
+    """Build a fake observer peer whose `conclusions_of(...).list(...)`
+    returns ``returned_page`` and records every call into ``calls``."""
+
+    class _Scope:
+        def __init__(self, target):
+            self.target = target
+
+        def list(self, page=1, size=50, reverse=False, **kwargs):
+            calls.append(("list", self.target, page, size, reverse))
+            return returned_page
+
+    class _Observer:
+        def conclusions_of(self, target):
+            calls.append(("conclusions_of", target))
+            return _Scope(target)
+
+    return _Observer()
+
+
+def _conclusion(idx, created_at="2026-01-01T00:00:00Z"):
+    return types.SimpleNamespace(
+        id=f"c-{idx}",
+        content=f"conclusion {idx}",
+        created_at=created_at,
+    )
+
+
+def test_list_honcho_conclusions_uses_syncpage_total(monkeypatch, tmp_path):
+    module = load_plugin_api(monkeypatch, tmp_path)
+    page = _FakeSyncPage(items=[_conclusion(1), _conclusion(2)], total=2076)
+    calls = []
+    observer = _make_observer_peer(page, calls)
+
+    items, total = module._list_honcho_conclusions(observer, "xraysight", limit=50)
+
+    assert total == 2076
+    assert len(items) == 2
+    assert [c["content"] for c in items] == ["conclusion 1", "conclusion 2"]
+    # Only one page request — no accidental pagination loop.
+    list_calls = [c for c in calls if c[0] == "list"]
+    assert len(list_calls) == 1
+
+
+def test_list_honcho_conclusions_falls_back_to_len_items(monkeypatch, tmp_path):
+    module = load_plugin_api(monkeypatch, tmp_path)
+    # Plain list — no `.items` / `.total` attributes; older SDK shape.
+    plain = [_conclusion(1), _conclusion(2), _conclusion(3)]
+    calls = []
+    observer = _make_observer_peer(plain, calls)
+
+    items, total = module._list_honcho_conclusions(observer, "xraysight", limit=50)
+
+    assert total == 3
+    assert len(items) == 3
+    list_calls = [c for c in calls if c[0] == "list"]
+    assert len(list_calls) == 1
+
+
+def test_list_honcho_conclusions_falls_back_when_total_is_none(monkeypatch, tmp_path):
+    module = load_plugin_api(monkeypatch, tmp_path)
+    # SyncPage with `total=None` despite non-empty items — guard against
+    # backends that omit pagination metadata.
+    page = _FakeSyncPage(items=[_conclusion(1), _conclusion(2)], total=None)
+    calls = []
+    observer = _make_observer_peer(page, calls)
+
+    items, total = module._list_honcho_conclusions(observer, "xraysight", limit=50)
+
+    assert total == 2  # not 0
+    assert len(items) == 2
+
+
+def test_list_honcho_conclusions_does_not_fetch_extra_pages(monkeypatch, tmp_path):
+    module = load_plugin_api(monkeypatch, tmp_path)
+    # Even when total >> page size, the function must use only the page
+    # items it was given, not call .list() repeatedly.
+    page = _FakeSyncPage(items=[_conclusion(i) for i in range(50)], total=2076)
+    calls = []
+    observer = _make_observer_peer(page, calls)
+
+    items, total = module._list_honcho_conclusions(observer, "xraysight", limit=50)
+
+    assert total == 2076
+    assert len(items) == 50
+    list_calls = [c for c in calls if c[0] == "list"]
+    assert len(list_calls) == 1, f"expected single page fetch, got {list_calls}"
+
+
 def test_honcho_payload_hides_api_key_and_fetches_peer_context(monkeypatch, tmp_path):
     (tmp_path / "config.yaml").write_text("memory:\n  provider: honcho\n", encoding="utf-8")
     (tmp_path / "honcho.json").write_text(json.dumps({"apiKey": "honcho-secret"}), encoding="utf-8")


### PR DESCRIPTION
## What

Honcho memory badges in the dashboard show the real database total instead of the page-limited array length. Closes #7.

Before: `11 card facts, 83 conclusions` on a workspace with 2076 conclusions.
After: `17 card facts, 816 conclusions (showing 100 latest)` reflecting the actual database state.

## Why

`DEFAULT_HONCHO_LIMIT = 50` / `MAX_HONCHO_LIMIT = 100` cap the per-request fetch — that's intentional pagination. The bug is that the UI rendered `card.length` and `conclusions.length` as if they were totals, so users couldn't tell whether Honcho had stopped writing or the dashboard was just paginated.

Honcho's Python SDK already exposes `SyncPage.total`. We were throwing it away.

## Changes

### Backend — `dashboard/plugin_api.py`
- `_list_honcho_conclusions` now returns `(items, total)`. `total` comes from `SyncPage.total` when available, with `len(items)` as a fallback for older SDK shapes.
- Items are explicitly sorted newest-first so the "showing N latest" hint stays correct even if the SDK ever changes its default ordering.
- `_honcho_payload` surfaces `total_conclusions` and `total_card_facts` on `base["user"]` and `base["ai"]`.

### Frontend — `dashboard/dist/index.js`
- Peer card badges prefer the new `total_conclusions` / `total_card_facts` fields, falling back to `array.length` so existing deployments don't break before they update the backend.
- When `total > items.length` the badge appends `(showing N latest)` so paginated views are unambiguous.
- The top-level "Honcho" stat card now displays total conclusions instead of card facts (the latter is always small and not very informative).

## Compatibility

- No new SDK requirement — `SyncPage.total` has been part of the Honcho Python SDK pagination contract for a while; the code falls back gracefully if it's missing.
- No changes to existing API field names; `total_conclusions` / `total_card_facts` are additive.
- No bundler/build-tool changes — `dist/index.js` is hand-edited like other commits in this repo.

## Test plan

Verified on a self-hosted Honcho (Docker Compose) workspace `hermes` with peer `XCOD33`:

- `curl /api/plugins/hermes-memory-ui/honcho?limit=100` returns:
  - `user.total_conclusions: 816`, `user.total_card_facts: 17`, `len(user.conclusions) = 100`
  - `ai.total_conclusions: 64`, `ai.total_card_facts: 0`, `len(ai.conclusions) = 64`
- Direct Honcho API count for `(observer=hermes-agent, observed=XCOD33)`: matches.
- UI badges show the real numbers and the `(showing N latest)` hint when paginated; the top-level Honcho stat card shows total conclusions.

## Notes

- This is purely read-side display. No Honcho writes, no schema changes, no auth changes.
- I considered exposing `total_observed` and `total_observer` as separate counters but kept this PR minimal — happy to add as a follow-up if the maintainers prefer.
