### PR TITLE
feat: add session search and improve theme compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Current scope:
 - Built-in memory:
   * `MEMORY.md` — agent notes / environment facts / project conventions
   * `USER.md` — user profile / preferences
+- Session search:
+  * explicit read-only search over previous Hermes sessions via Hermes' `session_search` tool
+  * optional source/type filter such as CLI, Telegram, cron, Discord, web, or API sessions
 - External memory providers:
   * Holographic memory:
     + local SQLite fact store, default: `$HERMES_HOME/memory_store.db`
@@ -131,6 +134,13 @@ Built-in memory section:
 - path, file existence, modification time
 - entry count and char usage bar
 - parsed entries
+
+Session search section:
+
+- explicit query box for previous Hermes sessions
+- optional session type/source filter
+- newest-first results with snippets and short message context
+- no automatic search on page load and no memory writes
 
 Holographic memory section, displayed only when `memory.provider` is currently `holographic`:
 
@@ -380,6 +390,23 @@ Returns parsed built-in memory stores:
 Entries are split on Hermes' built-in delimiter §.
 
 The response includes entry count, char count, configured/default char limits, usage percentage, file path, and modified timestamp.
+
+### GET `/session-search`
+
+Runs an explicit read-only search over previous Hermes sessions through Hermes' built-in `session_search` tool. This endpoint is not called from `/snapshot` or page load; the UI calls it only after the user submits a query.
+
+Query parameters:
+
+- `query`: required search query
+- `limit`: 1-10, default 3
+- `sort`: `newest` or `oldest`, default `newest`
+- `source`: optional exact source/type filter, e.g. `cli`, `telegram`, `cron`, `discord`, `web`, or `api`
+
+Example:
+
+```bash
+curl 'http://127.0.0.1:9119/api/plugins/hermes-memory-ui/session-search?query=dashboard&limit=3&sort=newest' | jq
+```
 
 ### GET `/holographic`
 

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -21,10 +21,11 @@
 
   function fmtTime(value) {
     if (!value) return "—";
-    if (typeof value === "number") {
-      return new Date(value * 1000).toLocaleString();
-    }
-    return String(value).replace("T", " ").replace(/\.\d+$/, "");
+    const date = typeof value === "number"
+      ? new Date(value < 1000000000000 ? value * 1000 : value)
+      : new Date(value);
+    if (Number.isNaN(date.getTime())) return String(value);
+    return date.toLocaleString(undefined, { dateStyle: "short", timeStyle: "medium" });
   }
 
   function pct(value) {
@@ -82,8 +83,8 @@
         e("div", { className: "memory-ui-title-row" },
           e(CardTitle, { className: "text-base" }, store.label),
           e("div", { className: "memory-ui-badges" },
-            e(Badge, { variant: "outline" }, store.entry_count + " entries"),
-            e(Badge, { variant: store.exists ? "outline" : "secondary" }, store.exists ? "file found" : "not created")
+            e(Badge, { tone: "outline" }, store.entry_count + " entries"),
+            e(Badge, { tone: store.exists ? "outline" : "secondary" }, store.exists ? "file found" : "not created")
           )
         ),
         e("button", { className: "memory-ui-link-button", onClick: function () { setExpanded(!expanded); } }, expanded ? "Collapse" : "Expand")
@@ -116,13 +117,118 @@
           e("h2", null, "Built-in memory"),
           e("p", null, "Read-only view of MEMORY.md and USER.md from the active Hermes profile.")
         ),
-        e(Badge, { variant: "outline" }, builtin.total_entries + " total entries")
+        e(Badge, { tone: "outline" }, builtin.total_entries + " total entries")
       ),
       e("div", { className: "memory-ui-grid-2" },
         (builtin.stores || []).map(function (store) {
           return e(BuiltinStoreCard, { key: store.id, store: store });
         })
       )
+    );
+  }
+
+  function SessionSearchResultRow(props) {
+    const result = props.result || {};
+    const messages = (result.messages || []).slice(0, 4);
+    const title = result.title || result.session_id || "Session";
+    return e("div", { className: "memory-ui-fact" },
+      e("div", { className: "memory-ui-fact-top" },
+        e(Badge, { tone: "outline" }, result.source || "session"),
+        result.when ? e("span", { className: "memory-ui-muted" }, result.when) : null,
+        result.match_message_id ? e("span", { className: "memory-ui-muted" }, "match #", result.match_message_id) : null
+      ),
+      e("div", { className: "memory-ui-fact-content" }, title),
+      result.snippet ? e("div", { className: "memory-ui-tags" }, result.snippet) : null,
+      messages.length ? e("div", { className: "memory-ui-entry-list" },
+        messages.map(function (message) {
+          return e("div", { key: "session-message-" + message.id, className: "memory-ui-entry" },
+            e("div", { className: "memory-ui-entry-index" }, message.role || "msg"),
+            e("div", { className: "memory-ui-entry-content" }, message.content || "")
+          );
+        })
+      ) : null
+    );
+  }
+
+  function SessionSearchSection() {
+    const [query, setQuery] = useState("");
+    const [source, setSource] = useState("");
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    function clearSearch() {
+      setQuery("");
+      setSource("");
+      setData(null);
+      setError(null);
+    }
+
+    function runSearch() {
+      if (!query.trim()) {
+        setError("Enter a session search query first.");
+        return;
+      }
+      const p = new URLSearchParams();
+      p.set("query", query.trim());
+      p.set("limit", "3");
+      p.set("sort", "newest");
+      if (source) p.set("source", source);
+      setLoading(true);
+      setError(null);
+      SDK.fetchJSON("/api/plugins/hermes-memory-ui/session-search?" + p.toString())
+        .then(function (payload) { setData(payload); })
+        .catch(function (err) { setError(err && err.message ? err.message : String(err)); })
+        .finally(function () { setLoading(false); });
+    }
+
+    const results = data && data.results ? data.results : [];
+    return e("div", { className: "memory-ui-section" },
+      e("div", { className: "memory-ui-section-header" },
+        e("div", null,
+          e("h2", null, "Session search"),
+          e("p", null, "Search previous Hermes sessions without changing memory state.")
+        ),
+        data ? e(Badge, { tone: "outline" }, (data.count || 0) + " matches") : null
+      ),
+      e("div", { className: "memory-ui-controls memory-ui-session-controls" },
+        e("div", { className: "memory-ui-control" },
+          e("label", null, "Query"),
+          e(Input, {
+            value: query,
+            placeholder: "search past sessions...",
+            onChange: function (ev) { setQuery(ev.target.value); },
+            onKeyDown: function (ev) { if (ev.key === "Enter") runSearch(); }
+          })
+        ),
+        e("div", { className: "memory-ui-control" },
+          e("label", null, "Session type"),
+          e("select", {
+            className: "memory-ui-select",
+            value: source,
+            onChange: function (ev) { setSource(ev.target.value); }
+          },
+            e("option", { value: "" }, "All sessions"),
+            e("option", { value: "cli" }, "CLI"),
+            e("option", { value: "telegram" }, "Telegram"),
+            e("option", { value: "cron" }, "Cron"),
+            e("option", { value: "discord" }, "Discord"),
+            e("option", { value: "web" }, "Web"),
+            e("option", { value: "api" }, "API")
+          )
+        ),
+        e("div", { className: "memory-ui-provider-actions" },
+          e(Button, { onClick: runSearch, className: "memory-ui-refresh", disabled: loading }, loading ? "Searching..." : "Search sessions"),
+          e(Button, { onClick: clearSearch, className: "memory-ui-refresh", outlined: true, disabled: loading && !query && !data && !source }, "Clear")
+        )
+      ),
+      e(ErrorBox, { error: error || (data && data.error) }),
+      data ? e("div", { className: "memory-ui-fact-list" },
+        e("div", { className: "memory-ui-muted" }, "Query: ", data.query || query, data.source ? " · type: " + data.source : "", data.message ? " · " + data.message : ""),
+        results.length
+          ? results.map(function (result, index) { return e(SessionSearchResultRow, { key: "session-search-" + index, result: result }); })
+          : e(EmptyState, null, data.error ? "Session search is unavailable." : "No matching sessions found.")
+      ) : null
     );
   }
 
@@ -137,7 +243,7 @@
     return e("div", { className: "memory-ui-fact" },
       e("div", { className: "memory-ui-fact-top" },
         e("div", { className: "memory-ui-fact-id" }, "#" + fact.fact_id),
-        e(Badge, { variant: "outline" }, fact.category || "general"),
+        e(Badge, { tone: "outline" }, fact.category || "general"),
         e(TrustPill, { score: fact.trust_score }),
         e("span", { className: "memory-ui-muted" }, "retrieved ", fact.retrieval_count || 0, "x"),
         e("span", { className: "memory-ui-muted" }, "helpful ", fact.helpful_count || 0, "x")
@@ -164,8 +270,8 @@
           e("p", null, "Read-only view of the local SQLite fact store used by the holographic provider.")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: data.exists ? "outline" : "secondary" }, data.exists ? "db found" : "db missing"),
-          e(Badge, { variant: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active")
+          e(Badge, { tone: data.exists ? "outline" : "secondary" }, data.exists ? "db found" : "db missing"),
+          e(Badge, { tone: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active")
         )
       ),
       e("div", { className: "memory-ui-grid-4" },
@@ -242,9 +348,9 @@
     return e("div", { className: "memory-ui-fact" },
       e("div", { className: "memory-ui-fact-top" },
         e("div", { className: "memory-ui-fact-id" }, "#" + memory.id),
-        memory.score !== null && memory.score !== undefined ? e(Badge, { variant: "outline" }, "score " + Number(memory.score).toFixed(3)) : null,
-        memory.user_id ? e(Badge, { variant: "outline" }, "user " + memory.user_id) : null,
-        memory.agent_id ? e(Badge, { variant: "outline" }, "agent " + memory.agent_id) : null
+        memory.score !== null && memory.score !== undefined ? e(Badge, { tone: "outline" }, "score " + Number(memory.score).toFixed(3)) : null,
+        memory.user_id ? e(Badge, { tone: "outline" }, "user " + memory.user_id) : null,
+        memory.agent_id ? e(Badge, { tone: "outline" }, "agent " + memory.agent_id) : null
       ),
       e("div", { className: "memory-ui-fact-content" }, memory.memory || ""),
       metadata ? e("div", { className: "memory-ui-tags" }, "metadata: ", metadata) : null,
@@ -266,9 +372,9 @@
           e("p", null, "Read-only view of Mem0 Platform memories scoped by the configured user_id.")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
-          e(Badge, { variant: "outline" }, "api mode"),
-          e(Badge, { variant: data.api_key_present ? "outline" : "secondary" }, data.api_key_present ? "api key present" : "no api key")
+          e(Badge, { tone: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
+          e(Badge, { tone: "outline" }, "api mode"),
+          e(Badge, { tone: data.api_key_present ? "outline" : "secondary" }, data.api_key_present ? "api key present" : "no api key")
         )
       ),
       e("div", { className: "memory-ui-grid-4" },
@@ -319,7 +425,7 @@
     return e("div", { className: "memory-ui-fact" },
       e("div", { className: "memory-ui-fact-top" },
         e("div", { className: "memory-ui-fact-id" }, "#" + conclusion.id),
-        conclusion.session_id ? e(Badge, { variant: "outline" }, "session " + conclusion.session_id) : null
+        conclusion.session_id ? e(Badge, { tone: "outline" }, "session " + conclusion.session_id) : null
       ),
       e("div", { className: "memory-ui-fact-content" }, conclusion.content || ""),
       e("div", { className: "memory-ui-muted" }, "Updated: ", fmtTime(conclusion.updated_at), " · Created: ", fmtTime(conclusion.created_at))
@@ -330,8 +436,8 @@
     const result = props.result;
     return e("div", { className: "memory-ui-fact" },
       e("div", { className: "memory-ui-fact-top" },
-        e(Badge, { variant: "outline" }, result.source || "match"),
-        result.peer_id ? e(Badge, { variant: "outline" }, "peer " + result.peer_id) : null,
+        e(Badge, { tone: "outline" }, result.source || "match"),
+        result.peer_id ? e(Badge, { tone: "outline" }, "peer " + result.peer_id) : null,
         result.id ? e("span", { className: "memory-ui-muted" }, "#" + result.id) : null
       ),
       e("div", { className: "memory-ui-fact-content" }, result.content || "")
@@ -350,8 +456,8 @@
           e("div", { className: "memory-ui-muted" }, peer.peer_id || "—")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: "outline" }, ((peer.total_card_facts != null ? peer.total_card_facts : card.length)) + " card facts"),
-          e(Badge, { variant: "outline" }, ((peer.total_conclusions != null ? peer.total_conclusions : conclusions.length)) + " conclusions" + (peer.total_conclusions != null && peer.total_conclusions > conclusions.length ? " (showing " + conclusions.length + " latest)" : ""))
+          e(Badge, { tone: "outline" }, ((peer.total_card_facts != null ? peer.total_card_facts : card.length)) + " card facts"),
+          e(Badge, { tone: "outline" }, ((peer.total_conclusions != null ? peer.total_conclusions : conclusions.length)) + " conclusions" + (peer.total_conclusions != null && peer.total_conclusions > conclusions.length ? " (showing " + conclusions.length + " latest)" : ""))
         )
       ),
       e(CardContent, null,
@@ -394,10 +500,10 @@
           e("p", null, "Read-only view of Honcho workspace, peers, cards, representations, conclusions, and context search.")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
-          e(Badge, { variant: data.api_key_present ? "outline" : "secondary" }, data.api_key_present ? "api key present" : "no api key"),
-          e(Badge, { variant: data.base_url_present ? "outline" : "secondary" }, data.base_url_present ? "base URL" : "cloud/default"),
-          e(Badge, { variant: "outline" }, data.recall_mode || "hybrid")
+          e(Badge, { tone: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
+          e(Badge, { tone: data.api_key_present ? "outline" : "secondary" }, data.api_key_present ? "api key present" : "no api key"),
+          e(Badge, { tone: data.base_url_present ? "outline" : "secondary" }, data.base_url_present ? "base URL" : "cloud/default"),
+          e(Badge, { tone: "outline" }, data.recall_mode || "hybrid")
         )
       ),
       e("div", { className: "memory-ui-grid-4" },
@@ -439,7 +545,7 @@
               e("div", { className: "memory-ui-muted" }, "Applied Honcho search"),
               e("div", { className: "memory-ui-fact-content" }, data.search)
             ),
-            e(Badge, { variant: "outline" }, (data.search_result_count || 0) + " text matches")
+            e(Badge, { tone: "outline" }, (data.search_result_count || 0) + " text matches")
           ),
           searchResults.length
             ? e("div", { className: "memory-ui-fact-list" }, searchResults.map(function (result, index) {
@@ -464,8 +570,8 @@
     return e("div", { className: "memory-ui-fact" },
       e("div", { className: "memory-ui-fact-top" },
         e("div", { className: "memory-ui-fact-id" }, "#" + result.id),
-        result.score !== null && result.score !== undefined ? e(Badge, { variant: "outline" }, "score " + Number(result.score).toFixed(3)) : null,
-        result.path ? e(Badge, { variant: "outline" }, result.path) : null
+        result.score !== null && result.score !== undefined ? e(Badge, { tone: "outline" }, "score " + Number(result.score).toFixed(3)) : null,
+        result.path ? e(Badge, { tone: "outline" }, result.path) : null
       ),
       result.title ? e("div", { className: "memory-ui-muted" }, result.title) : null,
       e("div", { className: "memory-ui-fact-content" }, result.excerpt || ""),
@@ -513,9 +619,9 @@
           e("p", null, "Read-only ByteRover memory search and explicit query results via brv CLI.")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
-          e(Badge, { variant: data.brv_available ? "outline" : "secondary" }, data.brv_available ? "brv found" : "brv missing"),
-          e(Badge, { variant: data.project_exists ? "outline" : "secondary" }, data.project_exists ? "project set" : "auto project")
+          e(Badge, { tone: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
+          e(Badge, { tone: data.brv_available ? "outline" : "secondary" }, data.brv_available ? "brv found" : "brv missing"),
+          e(Badge, { tone: data.project_exists ? "outline" : "secondary" }, data.project_exists ? "project set" : "auto project")
         )
       ),
       e("div", { className: "memory-ui-grid-1" },
@@ -590,8 +696,8 @@
     return e("div", { className: "memory-ui-fact" },
       e("div", { className: "memory-ui-fact-top" },
         e("div", { className: "memory-ui-fact-id" }, "#" + result.id),
-        result.score !== null && result.score !== undefined ? e(Badge, { variant: "outline" }, "score " + Number(result.score).toFixed(3)) : null,
-        typeLabel ? e(Badge, { variant: "outline" }, String(typeLabel).toUpperCase()) : null
+        result.score !== null && result.score !== undefined ? e(Badge, { tone: "outline" }, "score " + Number(result.score).toFixed(3)) : null,
+        typeLabel ? e(Badge, { tone: "outline" }, String(typeLabel).toUpperCase()) : null
       ),
       e("div", { className: "memory-ui-fact-content" }, result.text || ""),
       metadata ? e("div", { className: "memory-ui-tags" }, "metadata: ", metadata) : null
@@ -651,10 +757,10 @@
           e("p", null, "Read-only view of Hindsight config and bank contents, plus explicit recall/reflect. No retain/write calls are exposed.")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
-          e(Badge, { variant: "outline" }, data.mode || "cloud"),
-          e(Badge, { variant: data.api_key_present ? "outline" : "secondary" }, data.api_key_present ? "api key present" : "no api key"),
-          e(Badge, { variant: data.llm_key_present ? "outline" : "secondary" }, data.llm_key_present ? "LLM key present" : "no LLM key")
+          e(Badge, { tone: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
+          e(Badge, { tone: "outline" }, data.mode || "cloud"),
+          e(Badge, { tone: data.api_key_present ? "outline" : "secondary" }, data.api_key_present ? "api key present" : "no api key"),
+          e(Badge, { tone: data.llm_key_present ? "outline" : "secondary" }, data.llm_key_present ? "LLM key present" : "no LLM key")
         )
       ),
       e("div", { className: "memory-ui-grid-4" },
@@ -727,9 +833,9 @@
     return e("div", { className: "memory-ui-fact" },
       e("div", { className: "memory-ui-fact-top" },
         e("div", { className: "memory-ui-fact-id" }, "#" + result.id),
-        result.score !== null && result.score !== undefined ? e(Badge, { variant: "outline" }, "score " + Number(result.score).toFixed(3)) : null,
-        typeLabel ? e(Badge, { variant: "outline" }, String(typeLabel).toUpperCase()) : null,
-        result.source ? e(Badge, { variant: "outline" }, String(result.source)) : null
+        result.score !== null && result.score !== undefined ? e(Badge, { tone: "outline" }, "score " + Number(result.score).toFixed(3)) : null,
+        typeLabel ? e(Badge, { tone: "outline" }, String(typeLabel).toUpperCase()) : null,
+        result.source ? e(Badge, { tone: "outline" }, String(result.source)) : null
       ),
       e("div", { className: "memory-ui-fact-content" }, result.text || ""),
       metadata ? e("div", { className: "memory-ui-tags" }, "metadata: ", metadata) : null,
@@ -793,9 +899,9 @@
           e("p", null, "Read-only view of the local Mnemosyne SQLite store, plus explicit recall and injected-context preview.")
         ),
         e("div", { className: "memory-ui-badges" },
-          e(Badge, { variant: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
-          e(Badge, { variant: data.db_exists ? "outline" : "secondary" }, data.db_exists ? "db found" : "db missing"),
-          e(Badge, { variant: "outline" }, data.auto_sleep_enabled ? "sleep on" : "sleep off")
+          e(Badge, { tone: data.provider_configured ? "outline" : "secondary" }, data.provider_configured ? "active provider" : "not active"),
+          e(Badge, { tone: data.db_exists ? "outline" : "secondary" }, data.db_exists ? "db found" : "db missing"),
+          e(Badge, { tone: "outline" }, data.auto_sleep_enabled ? "sleep on" : "sleep off")
         )
       ),
       e("div", { className: "memory-ui-grid-4" },
@@ -925,7 +1031,7 @@
               e("p", { className: "memory-ui-muted" }, "Dashboard for Hermes built-in memory and active external memory providers.")
             ),
             e("div", { className: "memory-ui-badges" },
-              loading ? e(Badge, { variant: "secondary" }, "loading...") : null
+              loading ? e(Badge, { tone: "secondary" }, "loading...") : null
             )
           )
         ),
@@ -946,6 +1052,8 @@
       ),
       snapshot ? e(React.Fragment, null,
         e(BuiltinSection, { builtin: builtin }),
+        e(Separator, null),
+        e(SessionSearchSection, null),
         showHolographic ? e(React.Fragment, null,
           e(Separator, null),
           e(HolographicSection, { holographic: holographic, filters: filters, setFilters: setFilters, refresh: refresh })

--- a/dashboard/dist/style.css
+++ b/dashboard/dist/style.css
@@ -1,7 +1,7 @@
 .memory-ui-page {
   display: flex;
   flex-direction: column;
-  gap: calc(1rem * var(--spacing-mul, 1));
+  gap: calc(1rem * var(--theme-spacing-mul, 1));
 }
 
 .memory-ui-hero {
@@ -11,7 +11,7 @@
 .memory-ui-section {
   display: flex;
   flex-direction: column;
-  gap: calc(0.85rem * var(--spacing-mul, 1));
+  gap: calc(0.85rem * var(--theme-spacing-mul, 1));
 }
 
 .memory-ui-section-header,
@@ -46,7 +46,7 @@
 .memory-ui-grid-2,
 .memory-ui-grid-4 {
   display: grid;
-  gap: calc(0.8rem * var(--spacing-mul, 1));
+  gap: calc(0.8rem * var(--theme-spacing-mul, 1));
 }
 
 .memory-ui-grid-1 {
@@ -99,7 +99,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--color-card-foreground, var(--color-foreground));
+  font-family: var(--theme-font-mono, ui-monospace, monospace);
   font-size: 1.25rem;
   font-weight: 650;
 }
@@ -110,7 +111,7 @@
   border: 1px solid var(--color-border);
   background: color-mix(in srgb, var(--color-card), transparent 18%);
   color: var(--color-muted-foreground);
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--theme-font-mono, ui-monospace, monospace);
   font-size: 0.72rem;
   padding: 0.5rem 0.65rem;
 }
@@ -143,15 +144,15 @@
 }
 
 .memory-ui-usage-ok {
-  background: var(--color-success, #22c55e);
+  background: var(--color-success);
 }
 
 .memory-ui-usage-warn {
-  background: var(--color-warning, #f59e0b);
+  background: var(--color-warning);
 }
 
 .memory-ui-usage-danger {
-  background: var(--color-destructive, #ef4444);
+  background: var(--color-destructive);
 }
 
 .memory-ui-entry-list,
@@ -166,6 +167,7 @@
 .memory-ui-fact {
   border: 1px solid var(--color-border);
   background: color-mix(in srgb, var(--color-card), transparent 10%);
+  color: var(--color-card-foreground, var(--color-foreground));
   padding: 0.75rem;
 }
 
@@ -178,7 +180,7 @@
 .memory-ui-entry-index,
 .memory-ui-fact-id {
   color: var(--color-muted-foreground);
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--theme-font-mono, ui-monospace, monospace);
   font-size: 0.74rem;
 }
 
@@ -204,18 +206,18 @@
   border-radius: 999px;
   border: 1px solid var(--color-border);
   padding: 0.1rem 0.45rem;
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--theme-font-mono, ui-monospace, monospace);
   font-size: 0.72rem;
 }
 
 .memory-ui-trust-high {
-  color: var(--color-success, #22c55e);
-  border-color: color-mix(in srgb, var(--color-success, #22c55e), transparent 40%);
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success), transparent 40%);
 }
 
 .memory-ui-trust-mid {
-  color: var(--color-warning, #f59e0b);
-  border-color: color-mix(in srgb, var(--color-warning, #f59e0b), transparent 40%);
+  color: var(--color-warning);
+  border-color: color-mix(in srgb, var(--color-warning), transparent 40%);
 }
 
 .memory-ui-trust-low {
@@ -225,7 +227,7 @@
 .memory-ui-tags {
   margin-top: 0.5rem;
   color: var(--color-muted-foreground);
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--theme-font-mono, ui-monospace, monospace);
   font-size: 0.75rem;
 }
 
@@ -247,6 +249,10 @@
 
 .memory-ui-provider-controls {
   grid-template-columns: minmax(220px, 1fr) minmax(110px, 0.2fr) minmax(110px, 0.2fr) auto;
+}
+
+.memory-ui-session-controls {
+  grid-template-columns: minmax(220px, 1fr) minmax(130px, 0.28fr) auto;
 }
 
 .memory-ui-hindsight-actions,
@@ -306,8 +312,8 @@
   min-height: 2.35rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius, 0.5rem);
-  background: var(--color-background);
-  color: var(--color-foreground);
+  background: var(--color-popover, var(--color-background));
+  color: var(--color-popover-foreground, var(--color-foreground));
   padding: 0 0.65rem;
 }
 
@@ -325,9 +331,9 @@
 
 .memory-ui-error {
   border-style: solid;
-  border-color: color-mix(in srgb, var(--color-destructive, #ef4444), transparent 30%);
-  color: var(--color-destructive, #ef4444);
-  background: color-mix(in srgb, var(--color-destructive, #ef4444), transparent 92%);
+  border-color: color-mix(in srgb, var(--color-destructive), transparent 30%);
+  color: var(--color-destructive);
+  background: color-mix(in srgb, var(--color-destructive), transparent 92%);
 }
 
 .memory-ui-link-button {

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Memory",
   "description": "Read-only Hermes dashboard plugin for built-in, holographic, Mem0, Honcho, Mnemosyne, Hindsight, and ByteRover memory.",
   "icon": "Database",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "tab": {
     "path": "/memory",
     "position": "after:config"

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -37,7 +37,7 @@ except Exception:  # Allows local syntax/import tests outside the dashboard.
 
 router = APIRouter()
 
-PLUGIN_VERSION = "0.5.0"
+PLUGIN_VERSION = "0.5.2"
 ENTRY_DELIMITER = "\n§\n"
 DEFAULT_MEMORY_LIMIT = 2200
 DEFAULT_USER_LIMIT = 1375
@@ -54,6 +54,8 @@ MAX_MNEMOSYNE_LIMIT = 100
 DEFAULT_BYTEROVER_LIMIT = 10
 MAX_BYTEROVER_LIMIT = 50
 DEFAULT_BYTEROVER_QUERY_TIMEOUT = 60
+DEFAULT_SESSION_SEARCH_LIMIT = 3
+MAX_SESSION_SEARCH_LIMIT = 10
 HINDSIGHT_DEFAULT_CLOUD_URL = "https://api.hindsight.vectorize.io"
 HINDSIGHT_DEFAULT_LOCAL_URL = "http://localhost:8888"
 VALID_HINDSIGHT_BUDGETS = {"low", "mid", "high"}
@@ -267,6 +269,68 @@ def _builtin_payload(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         "total_entries": sum(s["entry_count"] for s in stores),
         "generated_at": time.time(),
     }
+
+
+def _session_search_payload(
+    *,
+    query: Optional[str],
+    limit: int = DEFAULT_SESSION_SEARCH_LIMIT,
+    sort: Optional[str] = "newest",
+    source: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run Hermes session_search as an explicit read-only dashboard action."""
+    query = query.strip() if isinstance(query, str) and query.strip() else ""
+    source = source.strip() if isinstance(source, str) and source.strip() else ""
+    try:
+        limit = int(limit or DEFAULT_SESSION_SEARCH_LIMIT)
+    except Exception:
+        limit = DEFAULT_SESSION_SEARCH_LIMIT
+    limit = max(1, min(limit, MAX_SESSION_SEARCH_LIMIT))
+    sort = sort if sort in {"newest", "oldest"} else "newest"
+
+    base: Dict[str, Any] = {
+        "id": "session_search",
+        "label": "Session search",
+        "mode": "read-only/query-only",
+        "query": query,
+        "source": source,
+        "limit": limit,
+        "sort": sort,
+        "results": [],
+        "count": 0,
+        "unfiltered_count": 0,
+        "error": None,
+        "generated_at": time.time(),
+    }
+    if not query:
+        base["error"] = "Query is required for session search."
+        return base
+    try:
+        from tools.session_search_tool import session_search as run_session_search  # type: ignore
+
+        search_limit = MAX_SESSION_SEARCH_LIMIT if source else limit
+        raw = run_session_search(query=query, limit=search_limit, sort=sort, role_filter="user,assistant")
+        data = json.loads(raw) if isinstance(raw, str) else raw
+        if not isinstance(data, dict):
+            base["error"] = "Session search returned an unexpected response."
+            return base
+        if data.get("success") is False:
+            base["error"] = _safe_error(data.get("error") or data.get("message") or "Session search failed.")
+            return base
+        results = data.get("results") if isinstance(data.get("results"), list) else []
+        base["unfiltered_count"] = len(results)
+        if source:
+            results = [item for item in results if str(item.get("source") or "").casefold() == source.casefold()]
+        results = results[:limit]
+        base.update({
+            "operation": data.get("mode") or "discover",
+            "results": results,
+            "count": len(results),
+            "message": data.get("message") or "",
+        })
+    except Exception as exc:
+        base["error"] = _safe_error(exc)
+    return base
 
 
 def _resolve_holographic_db(config: Dict[str, Any]) -> Path:
@@ -2250,6 +2314,16 @@ async def status() -> Dict[str, Any]:
 @router.get("/builtin")
 async def builtin() -> Dict[str, Any]:
     return _builtin_payload()
+
+
+@router.get("/session-search")
+async def session_search_endpoint(
+    query: str = Query(...),
+    limit: int = Query(DEFAULT_SESSION_SEARCH_LIMIT, ge=1, le=MAX_SESSION_SEARCH_LIMIT),
+    sort: str = Query("newest"),
+    source: Optional[str] = Query(None),
+) -> Dict[str, Any]:
+    return _session_search_payload(query=query, limit=limit, sort=sort, source=source or None)
 
 
 @router.get("/holographic")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 manifest_version: 1
 name: hermes-memory-ui
-version: 0.5.0
+version: 0.5.2
 description: "Read-only Hermes dashboard plugin for inspecting built-in, holographic, Mem0, Honcho, Mnemosyne, Hindsight, and ByteRover memory."
 homepage: "https://github.com/xraysight/hermes-memory-ui"

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -21,6 +21,52 @@ def load_plugin_api(monkeypatch, tmp_path):
     return module
 
 
+def test_session_search_payload_uses_hermes_session_search_tool(monkeypatch, tmp_path):
+    calls = []
+
+    fake_tools = types.ModuleType("tools")
+    fake_session_search_tool = types.ModuleType("tools.session_search_tool")
+
+    def fake_session_search(**kwargs):
+        calls.append(kwargs)
+        return json.dumps({
+            "success": True,
+            "mode": "discover",
+            "query": kwargs["query"],
+            "count": 2,
+            "results": [{
+                "session_id": "s1",
+                "title": "Memory UI work",
+                "when": "now",
+                "source": "cli",
+                "match_message_id": 42,
+                "snippet": "session search result",
+                "messages": [{"id": 42, "role": "user", "content": "find memory"}],
+            }, {
+                "session_id": "s2",
+                "title": "Telegram memory UI work",
+                "when": "now",
+                "source": "telegram",
+                "match_message_id": 43,
+                "snippet": "telegram result",
+                "messages": [{"id": 43, "role": "user", "content": "find memory from telegram"}],
+            }],
+        })
+
+    setattr(fake_session_search_tool, "session_search", fake_session_search)
+    monkeypatch.setitem(sys.modules, "tools", fake_tools)
+    monkeypatch.setitem(sys.modules, "tools.session_search_tool", fake_session_search_tool)
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    payload = module._session_search_payload(query="memory", limit=99, sort="newest", source="telegram")
+
+    assert payload["error"] is None
+    assert payload["count"] == 1
+    assert payload["source"] == "telegram"
+    assert payload["results"][0]["session_id"] == "s2"
+    assert calls == [{"query": "memory", "limit": 10, "sort": "newest", "role_filter": "user,assistant"}]
+
+
 def test_mem0_config_hides_api_key_and_uses_memory_client(monkeypatch, tmp_path):
     (tmp_path / "config.yaml").write_text("memory:\n  provider: mem0\n", encoding="utf-8")
     (tmp_path / "mem0.json").write_text(


### PR DESCRIPTION
**Summary**
- Add an explicit read-only Session search section backed by Hermes session_search        
- Add /session-search dashboard API endpoint with bounded limits, source filtering, and tests
- Improve dashboard theme compatibility by using SDK Badge tone, theme spacing/font CSS vars, semantic colors, and browser-local time formatting
- Preserve Honcho real-total badges from #8 while switching them to tone

**Notes**
- Session search is explicit user action only; it does not run from snapshot/page load.
- Backend route changes require dashboard restart after install/update because plugin APIs are mounted at startup.