### PR TITLE
fix: normalize known session source casing

### DIFF
--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -59,6 +59,12 @@ MAX_SESSION_SEARCH_LIMIT = 10
 SESSION_SEARCH_SCAN_LIMIT = 50
 SESSION_SOURCE_ALIASES = {
     "api": "api-server",
+    "api-server": "api-server",
+    "cli": "cli",
+    "telegram": "telegram",
+    "cron": "cron",
+    "discord": "discord",
+    "web": "web",
 }
 HINDSIGHT_DEFAULT_CLOUD_URL = "https://api.hindsight.vectorize.io"
 HINDSIGHT_DEFAULT_LOCAL_URL = "http://localhost:8888"

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -143,6 +143,26 @@ def test_session_search_payload_maps_api_source_to_api_server(monkeypatch, tmp_p
     assert db_calls[0]["source_filter"] == ["api-server"]
 
 
+def test_session_search_payload_normalizes_known_source_casing(monkeypatch, tmp_path):
+    db_calls = []
+
+    class FakeSessionDB:
+        def search_messages(self, **kwargs):
+            db_calls.append(kwargs)
+            return []
+
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = FakeSessionDB
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+
+    module = load_plugin_api(monkeypatch, tmp_path)
+    payload = module._session_search_payload(query="memory", source="Telegram")
+
+    assert payload["error"] is None
+    assert payload["source"] == "telegram"
+    assert db_calls[0]["source_filter"] == ["telegram"]
+
+
 def test_session_search_payload_preserves_custom_source_casing(monkeypatch, tmp_path):
     db_calls = []
 


### PR DESCRIPTION
**Summary**
- Address Codex review feedback from #11.
- Normalize known built-in session sources case-insensitively before querying SessionDB.search_messages(source_filter=...).
- Preserve original casing only for unknown/custom session sources.
- Add a regression test for mixed-case known source filters.
